### PR TITLE
🧙 Use magefile for build management 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,25 +38,23 @@ jobs:
         with:
           node-version: 18.12.0
 
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache: true
+          cache-dependency-path: |
+            **/go.sum
+            **/go.mod
+
+      - name: Install Mage
+        run: go install github.com/magefile/mage@v1.15
+        
       - name: Installing quicktype
         run: |
           yarn global add quicktype
           echo "$(yarn global bin)" >> $GITHUB_PATH
 
-      - name: Prepare package path
-        id: package
-        run: |
-          SCHEMA=${{ matrix.schema }}
-          PACKAGE_SRC=$(echo "ts/${SCHEMA/axone-/""}-schema")
-          mkdir ${PACKAGE_SRC}/gen-ts
-          echo "DESTINATION=$(echo "ts/${SCHEMA/axone-/""}-schema")" >> $GITHUB_OUTPUT
-
-      - name: Generate sources
-        run: |
-          quicktype -s schema schema/${{ matrix.schema }}/*.json -o ${{ steps.package.outputs.DESTINATION }}/gen-ts/schema.ts --prefer-types --prefer-unions
-
-      - name: Fetch dependencies
-        run: yarn --cwd ${{ steps.package.outputs.DESTINATION }}
-
       - name: Build
-        run: yarn --cwd ${{ steps.package.outputs.DESTINATION }} build
+        run: |
+          mage -v build:ts ${{ matrix.schema }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install Mage
         run: go install github.com/magefile/mage@v1.15
-        
+
       - name: Installing quicktype
         run: |
           yarn global add quicktype

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,10 @@ on:
   workflow_call:
 
   push:
-    branches: [ main ]
+    branches: [main]
 
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
   workflow_dispatch:
 
@@ -82,3 +82,45 @@ jobs:
           message: 🙅 Closing the PR because it does not respect naming conventions. Edit the branch name and submit a new PR.
     env:
       GITHUB_TOKEN: ${{ secrets.OPS_TOKEN }}
+
+  lint-magefiles:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find changed go files
+        id: changed-go-files
+        uses: tj-actions/changed-files@v44.5.2
+        with:
+          files: |
+            **/*.go
+            magefiles/go.mod
+            magefiles/go.sum
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v5.0.1
+        if: steps.changed-go-files.outputs.any_changed == 'true'
+        with:
+          go-version: "1.22"
+          cache: false
+
+      - name: Lint Mage go code (golangci-lint)
+        uses: golangci/golangci-lint-action@v6
+        if: steps.changed-go-files.outputs.any_changed == 'true'
+        with:
+          version: v1.59
+          working-directory: magefiles
+
+      - name: Lint Magefiles format (gofumpt)
+        if: steps.changed-go-files.outputs.any_changed == 'true'
+        run: |
+          go install mvdan.cc/gofumpt@v0.6.0
+          if [ "$(gofumpt -l magefiles)" != "" ]; then
+            echo "❌ Magefiles are not gofumpt!"
+            exit 1
+          fi
+          echo "✅ Magefiles are gofumpt!"

--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -63,11 +63,7 @@ jobs:
       
       - name: Install Mage
         run: go install github.com/magefile/mage@v1.15
-
-      - name: Download & generate schema
-        run: |
-          mage -v schema:generate ${{ github.event.inputs.ref }}
-
+      
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v5
         with:
@@ -77,34 +73,13 @@ jobs:
           git_user_signingkey: true
           git_commit_gpgsign: true
 
-      - name: Install gomplate
+      - name: Download & generate schema
         run: |
-          curl -s -L -o /usr/local/bin/gomplate https://github.com/hairyhenderson/gomplate/releases/download/v3.11.5/gomplate_linux-amd64
-          chmod +x /usr/local/bin/gomplate
+          mage -v schema:generate ${{ github.event.inputs.ref }}
 
-      - name: Copy updated schema and generate README
+      - name: Generate readme
         run: |
-          CONTRACTS=$(ls schema/ | jq -R -s -c 'split("\n")[:-1]')
-          for CONTRACT in $(echo ${CONTRACTS} | jq -r '.[]'); do
-            NAME=${CONTRACT/axone-/""}
-            SCHEMA_NAME=$NAME-schema
-
-            jq -n --rawfile docs tmp/docs/$CONTRACT.md \
-              --arg name "$NAME" \
-              --arg contract_name "$CONTRACT" \
-              --arg schema_name "$SCHEMA_NAME" \
-              --arg ref "${{ github.event.inputs.ref }}" \
-              '{docs: $docs, name: $name, contract_name: $contract_name, schema_name: $schema_name, ref: $ref}' > data.json
-
-            echo "📄 Generate $CONTRACT_NAME readme.md..."
-            gomplate -f ts/README.md.template -d data.json -o ts/$SCHEMA_NAME/README.md
-
-            rm data.json
-          done
-
-          git rm --ignore-unmatch --cached tmp
-          rm -rf .git/modules/tmp
-          rm -rf tmp
+          mage -v schema:readme ${{ github.event.inputs.ref }}
 
       - name: Setup node environment
         uses: actions/setup-node@v3

--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -60,10 +60,10 @@ jobs:
 
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1
-      
+
       - name: Install Mage
         run: go install github.com/magefile/mage@v1.15
-      
+
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v5
         with:

--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -31,14 +31,6 @@ jobs:
           token: ${{ secrets.OPS_TOKEN }}
           fetch-depth: 2
 
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.ref }}
-          repository: axone-protocol/contracts
-          token: ${{ secrets.OPS_TOKEN }}
-          path: tmp
-
       - name: Cache cargo registry
         uses: actions/cache@v3
         with:
@@ -50,20 +42,31 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache: true
+          cache-dependency-path: |
+              **/go.sum
+              **/go.mod
+
       - name: Setup rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.69
+          toolchain: 1.75
           default: true
           override: true
 
       - name: Install cargo make
         uses: davidB/rust-cargo-make@v1
+      
+      - name: Install Mage
+        run: go install github.com/magefile/mage@v1.15
 
-      - name: Build schema
+      - name: Download & generate schema
         run: |
-          cd tmp
-          cargo make schema
+          mage -v schema:generate ${{ github.event.inputs.ref }}
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v5
@@ -81,10 +84,6 @@ jobs:
 
       - name: Copy updated schema and generate README
         run: |
-          rm -rf schema/*
-          rsync -rmv --include='*/' --include='*/schema/raw/*.json' --exclude='*' tmp/contracts/ schema/
-          find schema -type f -name "*.json" -exec sh -c 'mv "{}" "$(dirname "{}" | xargs dirname | xargs dirname)"' \;
-
           CONTRACTS=$(ls schema/ | jq -R -s -c 'split("\n")[:-1]')
           for CONTRACT in $(echo ${CONTRACTS} | jq -r '.[]'); do
             NAME=${CONTRACT/axone-/""}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,35 @@ This repository contains [AXONE contract schemas](https://github.com/axone-proto
 
 - TypeScript ([ts](ts/))
 
+## Usage
+
+### Requirements
+
+- [mage](https://magefile.org/) 1.15+
+- [Go](https://golang.org/) 1.22+
+
+### Available commands
+
+```bash
+  build:ts           build typescript schema for the given contract schema.
+  schema:clean       remove temporary files
+  schema:download    download contracts schemas at a given ref.
+  schema:generate    build and generate contracts json schemas at the given ref.
+  schema:readme      generate contracts readme on all target
+```
+
+Download and generate schema for a specific version:
+
+```bash
+mage schema:generate v5.0.0
+```
+
+Build targeted language schema:
+
+```bash
+mage build:ts axone-objectarium
+```
+
 ## You want to get involved? 😍
 
 Please check out AXONE health files :

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -14,7 +14,7 @@ import (
 
 type Build mg.Namespace
 
-// Ts build typescript schemas
+// Ts build typescript schema for the given contract schema.
 func (Build) Ts(schema string) error {
 	fmt.Println("⚙️ Building typescript")
 

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -30,7 +30,7 @@ func (Build) Ts(schema string) error {
 			filepath.Join(dest, "gen-ts", "schema.ts")))
 
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to generate typescript types: %w", err)
 	}
 
 	err = sh.Run("yarn", "--cwd", dest)

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -23,13 +23,14 @@ func (Build) Ts(schema string) error {
 
 	name := strings.TrimPrefix(schema, "axone-")
 	dest := filepath.Join(TS_DIR, fmt.Sprintf("%s-schema", name))
-	os.Mkdir(filepath.Join(dest, "gen-ts"), os.ModePerm)
+	if err := os.Mkdir(filepath.Join(dest, "gen-ts"), os.ModePerm); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
 
 	err := sh.Run("bash", "-c",
 		fmt.Sprintf("quicktype -s schema %s -o %s --prefer-types --prefer-unions",
 			filepath.Join(SCHEMA_DIR, schema, "*.json"),
 			filepath.Join(dest, "gen-ts", "schema.ts")))
-
 	if err != nil {
 		return fmt.Errorf("failed to generate typescript types: %w", err)
 	}

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -1,15 +1,16 @@
-//go:build mage
-// +build mage
+//go:build (darwin && cgo) || linux || mage
+// +build darwin,cgo linux mage
 
 package main
 
 import (
 	"fmt"
-	"github.com/magefile/mage/mg"
-	"github.com/magefile/mage/sh"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
 )
 
 type Build mg.Namespace

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -1,0 +1,42 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"fmt"
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Build mg.Namespace
+
+// Ts build typescript schemas
+func (Build) Ts(schema string) error {
+	fmt.Println("⚙️ Building typescript")
+
+	ensureQuicktype()
+
+	name := strings.TrimPrefix(schema, "axone-")
+	dest := filepath.Join(TS_DIR, fmt.Sprintf("%s-schema", name))
+	os.Mkdir(filepath.Join(dest, "gen-ts"), os.ModePerm)
+
+	err := sh.Run("bash", "-c",
+		fmt.Sprintf("quicktype -s schema %s -o %s --prefer-types --prefer-unions",
+			filepath.Join(SCHEMA_DIR, schema, "*.json"),
+			filepath.Join(dest, "gen-ts", "schema.ts")))
+
+	if err != nil {
+		return err
+	}
+
+	err = sh.Run("yarn", "--cwd", dest)
+	if err != nil {
+		return err
+	}
+
+	return sh.Run("yarn", "--cwd", dest, "build")
+}

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -2,4 +2,4 @@ module github.com/axone-protocol/axone-contract-schema/magefiles
 
 go 1.22
 
-require github.com/magefile/mage v1.15.0 // indirect
+require github.com/magefile/mage v1.15.0

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -1,0 +1,5 @@
+module github.com/axone-protocol/axone-contract-schema/magefiles
+
+go 1.22
+
+require github.com/magefile/mage v1.15.0 // indirect

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,0 +1,2 @@
+github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
+github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -1,6 +1,3 @@
-//go:build mage
-// +build mage
-
 package main
 
 const (

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -3,10 +3,8 @@
 
 package main
 
+const SCHEMA_DIR = "schema"
+
 // Default target to run when none is specified
 // If not set, running mage will list available targets
 // var Default = Build
-
-
-
-

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -3,7 +3,10 @@
 
 package main
 
-const SCHEMA_DIR = "schema"
+const (
+	SCHEMA_DIR = "schema"
+	TS_DIR     = "ts"
+)
 
 // Default target to run when none is specified
 // If not set, running mage will list available targets

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -7,7 +7,3 @@ const (
 	SCHEMA_DIR = "schema"
 	TS_DIR     = "ts"
 )
-
-// Default target to run when none is specified
-// If not set, running mage will list available targets
-// var Default = Build

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -1,0 +1,12 @@
+//go:build mage
+// +build mage
+
+package main
+
+// Default target to run when none is specified
+// If not set, running mage will list available targets
+// var Default = Build
+
+
+
+

--- a/magefiles/readme.go
+++ b/magefiles/readme.go
@@ -1,6 +1,3 @@
-//go:build mage
-// +build mage
-
 package main
 
 import (

--- a/magefiles/readme.go
+++ b/magefiles/readme.go
@@ -1,0 +1,57 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+type ReadmeParams struct {
+	Docs         string
+	Name         string
+	ContractName string
+	SchemaName   string
+	Ref          string
+}
+
+func generateReadme(contract string) error {
+	fmt.Printf("    📄 Generating %s readme\n", contract)
+
+	readme, err := os.ReadFile(filepath.Join(CONTRACTS_TMP_DIR, "docs", fmt.Sprintf("%s.md", contract)))
+	name := strings.TrimPrefix(contract, "axone-")
+	schemaName := fmt.Sprintf("%s-schema", name)
+	if err != nil {
+		return err
+	}
+
+	params := ReadmeParams{
+		Docs:         string(readme),
+		Name:         name,
+		ContractName: contract,
+		SchemaName:   schemaName,
+		Ref:          tag(),
+	}
+
+	return ts(params)
+}
+
+func ts(params ReadmeParams) error {
+	fmt.Println("       ➡️ Typescript readme")
+	tmpl, err := template.ParseFiles(filepath.Join("ts", "README.md.template"))
+	if err != nil {
+		return err
+	}
+
+	readmeFile, err := os.Create(filepath.Join("ts", params.SchemaName, "README.md"))
+	if err != nil {
+		return err
+	}
+	defer readmeFile.Close()
+
+	return tmpl.Execute(readmeFile, params)
+}

--- a/magefiles/readme.go
+++ b/magefiles/readme.go
@@ -24,11 +24,12 @@ func generateReadme(contract string) error {
 	fmt.Printf("    📄 Generating %s readme\n", contract)
 
 	readme, err := os.ReadFile(filepath.Join(CONTRACTS_TMP_DIR, "docs", fmt.Sprintf("%s.md", contract)))
+	if err != nil {
+		return fmt.Errorf("could not read contract readme: %w", err)
+	}
+
 	name := strings.TrimPrefix(contract, "axone-")
 	schemaName := fmt.Sprintf("%s-schema", name)
-	if err != nil {
-		return err
-	}
 
 	params := ReadmeParams{
 		Docs:         string(readme),
@@ -44,14 +45,15 @@ func generateReadme(contract string) error {
 // generate typescript readmes
 func ts(params ReadmeParams) error {
 	fmt.Println("       ➡️ Typescript readme")
-	tmpl, err := template.ParseFiles(filepath.Join("ts", "README.md.template"))
+	tmplPath := filepath.Join("ts", "README.md.template")
+	tmpl, err := template.ParseFiles(tmplPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to parse template '%s': %w", tmplPath, err)
 	}
 
 	readmeFile, err := os.Create(filepath.Join("ts", params.SchemaName, "README.md"))
 	if err != nil {
-		return err
+		return fmt.Errorf("could not create readme file: %w", err)
 	}
 	defer readmeFile.Close()
 

--- a/magefiles/readme.go
+++ b/magefiles/readme.go
@@ -19,6 +19,7 @@ type ReadmeParams struct {
 	Ref          string
 }
 
+// generate readmes for the given contract in all target languages
 func generateReadme(contract string) error {
 	fmt.Printf("    📄 Generating %s readme\n", contract)
 
@@ -40,6 +41,7 @@ func generateReadme(contract string) error {
 	return ts(params)
 }
 
+// generate typescript readmes
 func ts(params ReadmeParams) error {
 	fmt.Println("       ➡️ Typescript readme")
 	tmpl, err := template.ParseFiles(filepath.Join("ts", "README.md.template"))

--- a/magefiles/schema.go
+++ b/magefiles/schema.go
@@ -57,7 +57,7 @@ func (s Schema) Generate(ref string) error {
 
 	runInPath(CONTRACTS_TMP_DIR, "cargo", "make", "schema")
 	if err := sh.Rm(SCHEMA_DIR); err != nil {
-		return err
+		return fmt.Errorf("failed to remove schema directory: %w", err)
 	}
 
 	fmt.Println("🔨 Moving generated json schema")
@@ -66,13 +66,13 @@ func (s Schema) Generate(ref string) error {
 
 	schemas, err := sh.Output("find", SCHEMA_DIR, "-type", "f", "-name", "*.json")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to find all json schema in '%s': %w", SCHEMA_DIR, err)
 	}
 
 	for _, schema := range strings.Split(schemas, "\n") {
 		dest := filepath.Join(schema, "../../../", filepath.Base(schema))
 		if err := os.Rename(schema, dest); err != nil {
-			return err
+			return fmt.Errorf("failed to move schema '%s' to '%s': %w", schema, dest, err)
 		}
 	}
 	fmt.Println("✨ Contracts json schema generated")
@@ -88,7 +88,7 @@ func (s Schema) Readme(ref string) error {
 
 	contractsDir, err := os.ReadDir(SCHEMA_DIR)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read contracts directory '%s': %w", SCHEMA_DIR, err)
 	}
 
 	for _, contract := range contractsDir {
@@ -98,7 +98,7 @@ func (s Schema) Readme(ref string) error {
 
 		err := generateReadme(contract.Name())
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to generate readme for contract '%s': %w", contract.Name(), err)
 		}
 	}
 	return nil

--- a/magefiles/schema.go
+++ b/magefiles/schema.go
@@ -15,7 +15,6 @@ import (
 const (
 	CONTRACTS_REPOSITORY = "https://github.com/axone-protocol/contracts.git"
 	CONTRACTS_TMP_DIR    = "tmp"
-	SCHEMA_DIR           = "schema"
 )
 
 type Schema mg.Namespace
@@ -40,7 +39,7 @@ func (Schema) Download(ref string) error {
 	return nil
 }
 
-// Generate build and generate contracts json schema
+// Generate build and generate contracts json schema and readme
 func (s Schema) Generate(ref string) error {
 	mg.Deps(mg.F(Schema.Download, ref))
 
@@ -74,6 +73,36 @@ func (s Schema) Generate(ref string) error {
 	}
 	fmt.Println("✨ Contracts json schema generated")
 	return nil
+}
+
+// Readme generate contracts readme on all target
+func (s Schema) Readme(ref string) error {
+	mg.Deps(mg.F(Schema.Download, ref))
+
+	fmt.Println("📄 Generating contracts readme")
+
+	contractsDir, err := os.ReadDir(SCHEMA_DIR)
+	if err != nil {
+		return err
+	}
+
+	for _, contract := range contractsDir {
+		if !contract.IsDir() {
+			continue
+		}
+
+		err := generateReadme(contract.Name())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// tag returns the git tag for the current branch or "" if none.
+func tag() string {
+	s, _ := sh.Output("git", "describe", "--tags")
+	return s
 }
 
 // Clean remove temporary files

--- a/magefiles/schema.go
+++ b/magefiles/schema.go
@@ -19,7 +19,8 @@ const (
 
 type Schema mg.Namespace
 
-// Download download contracts schemas
+// Download download contracts schemas at a given ref.
+// ref can be a branch, tag or commit hash.
 func (Schema) Download(ref string) error {
 	mg.Deps(Schema.Clean)
 
@@ -39,7 +40,10 @@ func (Schema) Download(ref string) error {
 	return nil
 }
 
-// Generate build and generate contracts json schema and readme
+// Generate build and generate contracts json schemas at the given ref.
+// It first downloads the contracts repository at the given ref., then
+// generate the json schema using cargo make and finally move the generated schema to the schema directory.
+// ref can be a branch, tag or commit hash.
 func (s Schema) Generate(ref string) error {
 	mg.Deps(mg.F(Schema.Download, ref))
 

--- a/magefiles/schema.go
+++ b/magefiles/schema.go
@@ -4,110 +4,110 @@
 package main
 
 import (
-    "fmt"
-    "github.com/magefile/mage/mg"
-    "github.com/magefile/mage/sh"
-    "os"
-    "path/filepath"
-    "strings"
+	"fmt"
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
 const (
-    CONTRACTS_REPOSITORY = "https://github.com/axone-protocol/contracts.git"
-    CONTRACTS_TMP_DIR    = "tmp"
+	CONTRACTS_REPOSITORY = "https://github.com/axone-protocol/contracts.git"
+	CONTRACTS_TMP_DIR    = "tmp"
 )
 
 type Schema mg.Namespace
 
 // Download download contracts schemas
 func (Schema) Download(ref string) error {
-    mg.Deps(Schema.Clean)
+	mg.Deps(Schema.Clean)
 
-    fmt.Println("📥 Downloading contracts schemas")
+	fmt.Println("📥 Downloading contracts schemas")
 
-    EnsureGit()
+	ensureGit()
 
-    if err := sh.Run("git",
-        "clone",
-        "--depth", "1",
-        "--branch", ref,
-        CONTRACTS_REPOSITORY,
-        CONTRACTS_TMP_DIR); err != nil {
-        return err
-    }
+	if err := sh.Run("git",
+		"clone",
+		"--depth", "1",
+		"--branch", ref,
+		CONTRACTS_REPOSITORY,
+		CONTRACTS_TMP_DIR); err != nil {
+		return err
+	}
 
-    return nil
+	return nil
 }
 
 // Generate build and generate contracts json schema and readme
 func (s Schema) Generate(ref string) error {
-    mg.Deps(mg.F(Schema.Download, ref))
+	mg.Deps(mg.F(Schema.Download, ref))
 
-    defer func() {
-        s.Clean()
-    }()
+	defer func() {
+		s.Clean()
+	}()
 
-    fmt.Println("🔨 Generating contracts json schema")
+	fmt.Println("🔨 Generating contracts json schema")
 
-    EnsureCargoMake()
+	ensureCargoMake()
 
-    RunInPath(CONTRACTS_TMP_DIR, "cargo", "make", "schema")
-    if err := sh.Rm(SCHEMA_DIR); err != nil {
-        return err
-    }
+	runInPath(CONTRACTS_TMP_DIR, "cargo", "make", "schema")
+	if err := sh.Rm(SCHEMA_DIR); err != nil {
+		return err
+	}
 
-    fmt.Println("🔨 Moving generated json schema")
-    err := sh.Run("bash", "-c",
-        fmt.Sprintf("rsync -rmv --include='*/' --include='*/schema/raw/*.json' --exclude='*' %s/contracts/ %s/", CONTRACTS_TMP_DIR, SCHEMA_DIR))
+	fmt.Println("🔨 Moving generated json schema")
+	err := sh.Run("bash", "-c",
+		fmt.Sprintf("rsync -rmv --include='*/' --include='*/schema/raw/*.json' --exclude='*' %s/contracts/ %s/", CONTRACTS_TMP_DIR, SCHEMA_DIR))
 
-    schemas, err := sh.Output("find", SCHEMA_DIR, "-type", "f", "-name", "*.json")
-    if err != nil {
-        return err
-    }
+	schemas, err := sh.Output("find", SCHEMA_DIR, "-type", "f", "-name", "*.json")
+	if err != nil {
+		return err
+	}
 
-    for _, schema := range strings.Split(schemas, "\n") {
-        dest := filepath.Join(schema, "../../../", filepath.Base(schema))
-        if err := os.Rename(schema, dest); err != nil {
-            return err
-        }
-    }
-    fmt.Println("✨ Contracts json schema generated")
-    return nil
+	for _, schema := range strings.Split(schemas, "\n") {
+		dest := filepath.Join(schema, "../../../", filepath.Base(schema))
+		if err := os.Rename(schema, dest); err != nil {
+			return err
+		}
+	}
+	fmt.Println("✨ Contracts json schema generated")
+	return nil
 }
 
 // Readme generate contracts readme on all target
 func (s Schema) Readme(ref string) error {
-    mg.Deps(mg.F(Schema.Download, ref))
-    defer s.Clean()
+	mg.Deps(mg.F(Schema.Download, ref))
+	defer s.Clean()
 
-    fmt.Println("📄 Generating contracts readme")
+	fmt.Println("📄 Generating contracts readme")
 
-    contractsDir, err := os.ReadDir(SCHEMA_DIR)
-    if err != nil {
-        return err
-    }
+	contractsDir, err := os.ReadDir(SCHEMA_DIR)
+	if err != nil {
+		return err
+	}
 
-    for _, contract := range contractsDir {
-        if !contract.IsDir() {
-            continue
-        }
+	for _, contract := range contractsDir {
+		if !contract.IsDir() {
+			continue
+		}
 
-        err := generateReadme(contract.Name())
-        if err != nil {
-            return err
-        }
-    }
-    return nil
+		err := generateReadme(contract.Name())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // tag returns the git tag for the current branch or "" if none.
 func tag() string {
-    s, _ := sh.Output("git", "describe", "--tags")
-    return s
+	s, _ := sh.Output("git", "describe", "--tags")
+	return s
 }
 
 // Clean remove temporary files
 func (Schema) Clean() error {
-    fmt.Println("🧹 Cleaning schema temporary files")
-    return sh.Rm(CONTRACTS_TMP_DIR)
+	fmt.Println("🧹 Cleaning schema temporary files")
+	return sh.Rm(CONTRACTS_TMP_DIR)
 }

--- a/magefiles/schema.go
+++ b/magefiles/schema.go
@@ -47,9 +47,7 @@ func (Schema) Download(ref string) error {
 func (s Schema) Generate(ref string) error {
 	mg.Deps(mg.F(Schema.Download, ref))
 
-	defer func() {
-		s.Clean()
-	}()
+	defer s.Clean()
 
 	fmt.Println("🔨 Generating contracts json schema")
 

--- a/magefiles/schema.go
+++ b/magefiles/schema.go
@@ -1,15 +1,13 @@
-//go:build mage
-// +build mage
-
 package main
 
 import (
 	"fmt"
-	"github.com/magefile/mage/mg"
-	"github.com/magefile/mage/sh"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
 )
 
 const (

--- a/magefiles/schema.go
+++ b/magefiles/schema.go
@@ -1,0 +1,69 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"fmt"
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+)
+
+const (
+	CONTRACTS_REPOSITORY = "https://github.com/axone-protocol/contracts.git"
+	CONTRACTS_TMP_DIR    = "tmp/contracts"
+)
+
+type Schema mg.Namespace
+
+// Download download contracts schemas
+func (Schema) Download(ref string) error {
+	mg.Deps(Schema.Clean)
+
+	fmt.Println("📥 Downloading contracts schemas")
+
+	ensureGit()
+
+	if err := sh.Run("git",
+		"clone",
+		"--depth", "1",
+		"--branch", ref,
+		CONTRACTS_REPOSITORY,
+		CONTRACTS_TMP_DIR); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Generate build and generate contracts json schema
+func (s Schema) Generate(ref string) error {
+	mg.Deps(mg.F(Schema.Download, ref))
+
+	defer func() {
+		s.Clean()
+	}()
+
+	fmt.Println("🔨 Generating contracts json schema")
+
+	ensureCargo()
+
+	return nil
+}
+
+func (Schema) Clean() error {
+	fmt.Println("🧹 Cleaning schema temporary files")
+	return sh.Rm(CONTRACTS_TMP_DIR)
+}
+
+func ensureGit() {
+	if err := sh.Run("command", "-v", "git"); err != nil {
+		panic("git is not installed")
+	}
+}
+
+func ensureCargo() {
+	if err := sh.Run("command", "-v", "cargo"); err != nil {
+		panic("cargo is not installed")
+	}
+}

--- a/magefiles/schema.go
+++ b/magefiles/schema.go
@@ -4,109 +4,110 @@
 package main
 
 import (
-	"fmt"
-	"github.com/magefile/mage/mg"
-	"github.com/magefile/mage/sh"
-	"os"
-	"path/filepath"
-	"strings"
+    "fmt"
+    "github.com/magefile/mage/mg"
+    "github.com/magefile/mage/sh"
+    "os"
+    "path/filepath"
+    "strings"
 )
 
 const (
-	CONTRACTS_REPOSITORY = "https://github.com/axone-protocol/contracts.git"
-	CONTRACTS_TMP_DIR    = "tmp"
+    CONTRACTS_REPOSITORY = "https://github.com/axone-protocol/contracts.git"
+    CONTRACTS_TMP_DIR    = "tmp"
 )
 
 type Schema mg.Namespace
 
 // Download download contracts schemas
 func (Schema) Download(ref string) error {
-	mg.Deps(Schema.Clean)
+    mg.Deps(Schema.Clean)
 
-	fmt.Println("📥 Downloading contracts schemas")
+    fmt.Println("📥 Downloading contracts schemas")
 
-	EnsureGit()
+    EnsureGit()
 
-	if err := sh.Run("git",
-		"clone",
-		"--depth", "1",
-		"--branch", ref,
-		CONTRACTS_REPOSITORY,
-		CONTRACTS_TMP_DIR); err != nil {
-		return err
-	}
+    if err := sh.Run("git",
+        "clone",
+        "--depth", "1",
+        "--branch", ref,
+        CONTRACTS_REPOSITORY,
+        CONTRACTS_TMP_DIR); err != nil {
+        return err
+    }
 
-	return nil
+    return nil
 }
 
 // Generate build and generate contracts json schema and readme
 func (s Schema) Generate(ref string) error {
-	mg.Deps(mg.F(Schema.Download, ref))
+    mg.Deps(mg.F(Schema.Download, ref))
 
-	defer func() {
-		s.Clean()
-	}()
+    defer func() {
+        s.Clean()
+    }()
 
-	fmt.Println("🔨 Generating contracts json schema")
+    fmt.Println("🔨 Generating contracts json schema")
 
-	EnsureCargoMake()
+    EnsureCargoMake()
 
-	RunInPath(CONTRACTS_TMP_DIR, "cargo", "make", "schema")
-	if err := sh.Rm(SCHEMA_DIR); err != nil {
-		return err
-	}
+    RunInPath(CONTRACTS_TMP_DIR, "cargo", "make", "schema")
+    if err := sh.Rm(SCHEMA_DIR); err != nil {
+        return err
+    }
 
-	fmt.Println("🔨 Moving generated json schema")
-	err := sh.Run("bash", "-c",
-		fmt.Sprintf("rsync -rmv --include='*/' --include='*/schema/raw/*.json' --exclude='*' %s/contracts/ %s/", CONTRACTS_TMP_DIR, SCHEMA_DIR))
+    fmt.Println("🔨 Moving generated json schema")
+    err := sh.Run("bash", "-c",
+        fmt.Sprintf("rsync -rmv --include='*/' --include='*/schema/raw/*.json' --exclude='*' %s/contracts/ %s/", CONTRACTS_TMP_DIR, SCHEMA_DIR))
 
-	schemas, err := sh.Output("find", SCHEMA_DIR, "-type", "f", "-name", "*.json")
-	if err != nil {
-		return err
-	}
+    schemas, err := sh.Output("find", SCHEMA_DIR, "-type", "f", "-name", "*.json")
+    if err != nil {
+        return err
+    }
 
-	for _, schema := range strings.Split(schemas, "\n") {
-		dest := filepath.Join(schema, "../../../", filepath.Base(schema))
-		if err := os.Rename(schema, dest); err != nil {
-			return err
-		}
-	}
-	fmt.Println("✨ Contracts json schema generated")
-	return nil
+    for _, schema := range strings.Split(schemas, "\n") {
+        dest := filepath.Join(schema, "../../../", filepath.Base(schema))
+        if err := os.Rename(schema, dest); err != nil {
+            return err
+        }
+    }
+    fmt.Println("✨ Contracts json schema generated")
+    return nil
 }
 
 // Readme generate contracts readme on all target
 func (s Schema) Readme(ref string) error {
-	mg.Deps(mg.F(Schema.Download, ref))
+    mg.Deps(mg.F(Schema.Download, ref))
+    defer s.Clean()
 
-	fmt.Println("📄 Generating contracts readme")
+    fmt.Println("📄 Generating contracts readme")
 
-	contractsDir, err := os.ReadDir(SCHEMA_DIR)
-	if err != nil {
-		return err
-	}
+    contractsDir, err := os.ReadDir(SCHEMA_DIR)
+    if err != nil {
+        return err
+    }
 
-	for _, contract := range contractsDir {
-		if !contract.IsDir() {
-			continue
-		}
+    for _, contract := range contractsDir {
+        if !contract.IsDir() {
+            continue
+        }
 
-		err := generateReadme(contract.Name())
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+        err := generateReadme(contract.Name())
+        if err != nil {
+            return err
+        }
+    }
+    return nil
 }
 
 // tag returns the git tag for the current branch or "" if none.
 func tag() string {
-	s, _ := sh.Output("git", "describe", "--tags")
-	return s
+    s, _ := sh.Output("git", "describe", "--tags")
+    return s
 }
 
 // Clean remove temporary files
 func (Schema) Clean() error {
-	fmt.Println("🧹 Cleaning schema temporary files")
-	return sh.Rm(CONTRACTS_TMP_DIR)
+    fmt.Println("🧹 Cleaning schema temporary files")
+    return sh.Rm(CONTRACTS_TMP_DIR)
 }

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"github.com/magefile/mage/sh"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RunInPath runs a command in a specific path.
+func RunInPath(path string, cmd string, args ...string) error {
+	err := os.Chdir(path)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		dirs := filepath.SplitList(path)
+		os.Chdir(strings.Repeat("../", len(dirs)))
+	}()
+
+	return sh.Run(cmd, args...)
+}
+
+// EnsureGit ensures that git is installed, if not it panics.
+func EnsureGit() {
+	if err := sh.Run("command", "-v", "git"); err != nil {
+		panic("git is not installed")
+	}
+}
+
+// EnsureCargo ensures that cargo is installed, if not it panics.
+func EnsureCargo() {
+	if err := sh.Run("command", "-v", "cargo"); err != nil {
+		panic("cargo is not installed")
+	}
+}
+
+// EnsureCargoMake ensures that cargo-make is installed, if not, it tries to install it.
+func EnsureCargoMake() {
+	EnsureCargo()
+
+	if err := sh.Run("cargo", "make", "--help"); err == nil {
+		return
+	}
+
+	sh.Run("cargo", "install", "--force", "cargo-make")
+}

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/magefile/mage/sh"
 	"os"
 	"path/filepath"
@@ -52,7 +53,9 @@ func ensureCargoMake() {
 
 // EnsureQuicktype ensures that quicktype is installed, if not it panics.
 func ensureQuicktype() {
-	if err := sh.Run("command", "-v", "quicktype"); err != nil {
+	t, e := sh.Output("type", "quicktype")
+	fmt.Printf("⚠️ : %s, error : %s\n", t, e)
+	if err := sh.Run("type", "quicktype"); err != nil {
 		panic("quicktype is not installed")
 	}
 }

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -1,3 +1,6 @@
+//go:build mage
+// +build mage
+
 package main
 
 import (
@@ -8,7 +11,7 @@ import (
 )
 
 // RunInPath runs a command in a specific path.
-func RunInPath(path string, cmd string, args ...string) error {
+func runInPath(path string, cmd string, args ...string) error {
 	err := os.Chdir(path)
 	if err != nil {
 		return err
@@ -23,26 +26,33 @@ func RunInPath(path string, cmd string, args ...string) error {
 }
 
 // EnsureGit ensures that git is installed, if not it panics.
-func EnsureGit() {
+func ensureGit() {
 	if err := sh.Run("command", "-v", "git"); err != nil {
 		panic("git is not installed")
 	}
 }
 
 // EnsureCargo ensures that cargo is installed, if not it panics.
-func EnsureCargo() {
+func ensureCargo() {
 	if err := sh.Run("command", "-v", "cargo"); err != nil {
 		panic("cargo is not installed")
 	}
 }
 
 // EnsureCargoMake ensures that cargo-make is installed, if not, it tries to install it.
-func EnsureCargoMake() {
-	EnsureCargo()
+func ensureCargoMake() {
+	ensureCargo()
 
 	if err := sh.Run("cargo", "make", "--help"); err == nil {
 		return
 	}
 
 	sh.Run("cargo", "install", "--force", "cargo-make")
+}
+
+// EnsureQuicktype ensures that quicktype is installed, if not it panics.
+func ensureQuicktype() {
+	if err := sh.Run("command", "-v", "quicktype"); err != nil {
+		panic("quicktype is not installed")
+	}
 }

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -1,13 +1,11 @@
-//go:build mage
-// +build mage
-
 package main
 
 import (
-	"github.com/magefile/mage/sh"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/magefile/mage/sh"
 )
 
 // RunInPath runs a command in a specific path.

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,7 +18,7 @@ func runInPath(path string, cmd string, args ...string) error {
 
 	defer func() {
 		dirs := filepath.SplitList(path)
-		os.Chdir(strings.Repeat("../", len(dirs)))
+		_ = os.Chdir(strings.Repeat("../", len(dirs)))
 	}()
 
 	return sh.Run(cmd, args...)
@@ -41,11 +42,11 @@ func ensureCargo() {
 func ensureCargoMake() {
 	ensureCargo()
 
-	if err := sh.Run("cargo", "make", "--help"); err == nil {
-		return
+	if err := sh.Run("cargo", "make", "--help"); err != nil {
+		if err := sh.Run("cargo", "install", "cargo-make"); err != nil {
+			panic(fmt.Sprintf("failed to install cargo-make: %v", err))
+		}
 	}
-
-	sh.Run("cargo", "install", "--force", "cargo-make")
 }
 
 // EnsureQuicktype ensures that quicktype is installed, if not it panics.

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/magefile/mage/sh"
 	"os"
 	"path/filepath"
@@ -28,14 +27,14 @@ func runInPath(path string, cmd string, args ...string) error {
 
 // EnsureGit ensures that git is installed, if not it panics.
 func ensureGit() {
-	if err := sh.Run("command", "-v", "git"); err != nil {
+	if err := sh.Run("git", "--help"); err != nil {
 		panic("git is not installed")
 	}
 }
 
 // EnsureCargo ensures that cargo is installed, if not it panics.
 func ensureCargo() {
-	if err := sh.Run("command", "-v", "cargo"); err != nil {
+	if err := sh.Run("cargo", "--help"); err != nil {
 		panic("cargo is not installed")
 	}
 }
@@ -53,9 +52,7 @@ func ensureCargoMake() {
 
 // EnsureQuicktype ensures that quicktype is installed, if not it panics.
 func ensureQuicktype() {
-	t, e := sh.Output("type", "quicktype")
-	fmt.Printf("⚠️ : %s, error : %s\n", t, e)
-	if err := sh.Run("type", "quicktype"); err != nil {
+	if err := sh.Run("quicktype", "--help"); err != nil {
 		panic("quicktype is not installed")
 	}
 }

--- a/ts/README.md.template
+++ b/ts/README.md.template
@@ -1,6 +1,6 @@
-# AXONE {{ (ds "data").name }} schema
+# AXONE {{ .Name }} schema
 
-> Generated typescript types for [{{ (ds "data").contract_name }} contract](https://github.com/axone-protocol/contracts/tree/{{ (ds "data").ref }}/contracts/{{ (ds "data").contract_name }}).
+> Generated typescript types for [{{ .ContractName }} contract](https://github.com/axone-protocol/contracts/tree/{{ .Ref }}/contracts/{{ .ContractName }}).
 
 [![version](https://img.shields.io/github/v/release/axone-protocol/axone-contract-schema?style=for-the-badge&logo=github)](https://github.com/axone-protocol/axone-contract-schema/releases)
 [![build](https://img.shields.io/github/actions/workflow/status/axone-protocol/axone-contract-schema/build.yml?branch=main&label=build&style=for-the-badge&logo=github)](https://github.com/axone-protocol/axone-contract-schema/actions/workflows/build.yml)
@@ -11,26 +11,26 @@
 [![contributor covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](https://github.com/axone-protocol/.github/blob/main/CODE_OF_CONDUCT.md)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg?style=for-the-badge)](https://opensource.org/licenses/BSD-3-Clause)
 
-## Usage 
+## Usage
 
-First add or install the module to your existing project using either `yarn` or `npm`. 
+First add or install the module to your existing project using either `yarn` or `npm`.
 
 ```bash
-yarn add @axone/{{ (ds "data").schema_name }}
+yarn add @axone/{{ .SchemaName }}
 ```
 
-or 
+or
 ```bash
-npm install --save @axone/{{ (ds "data").schema_name }}
+npm install --save @axone/{{ .SchemaName }}
 ```
 
-Then import wanted type : 
+Then import wanted type :
 
 ```typescript
-import type { InstantiateMsg } from "@axone/{{ (ds "data").schema_name }}";
+import type { InstantiateMsg } from "@axone/{{ .SchemaName }}";
 ```
 
 ---
 
-{{ (ds "data").docs }}
+{{ .Docs }}
 


### PR DESCRIPTION
This pull request introduces a significant refactoring of the build process by incorporating the [Mage](https://magefile.org/) build tool. Mage allows us to write our build scripts in Go, providing a more robust and maintainable approach compared to traditional shell scripts. See #24.

### 👩‍💻 Usage 

Here the list of available command that I've introduced : 

```bash
  build:ts           build typescript schema for the given contract schema.
  schema:clean       remove temporary files
  schema:download    download contracts schemas at a given ref.
  schema:generate    build and generate contracts json schemas at the given ref.
  schema:readme      generate contracts readme on all target
```

This command will download schema located in contracts repository from the main branch and generated appropriate schema into this repository.

```bash
mage schema:generate main
```

### 📋 Next step

Since typescript generation is not used for now and contains some issue on the generated files (#9), I propose to implement the publish action with mage for the next development (#26 )