### PR TITLE
[Go] ♻️ Replace `quicktype` by `go-codegen`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,11 +51,6 @@ jobs:
       - name: Install Mage
         run: go install github.com/magefile/mage@v1.15
 
-      - name: Installing quicktype
-        run: |
-          yarn global add quicktype@23
-          echo "$(yarn global bin)" >> $GITHUB_PATH
-
       - name: Build
         run: |
           mage -v build:${{ matrix.target }} ${{ matrix.schema }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,8 +72,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets[matrix.registry.auth-token-secret] }}
 
+  create_release:
+    runs-on: ubuntu-22.04
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - lint
+      - build
+    steps:
       - name: Create release
         uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           body: Schema changelog avalaible on [contract repository](https://github.com/axone-protocol/contracts/blob/${{ github.ref_name }}/CHANGELOG.md).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,11 +66,6 @@ jobs:
       - name: Install Mage
         run: go install github.com/magefile/mage@v1.15
 
-      - name: Installing quicktype
-        run: |
-          yarn global add quicktype@23
-          echo "$(yarn global bin)" >> $GITHUB_PATH
-
       - name: Publish
         run: |
           mage -v publish:ts ${{ matrix.schema }} $GITHUB_REF

--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -122,11 +122,6 @@ jobs:
       - name: Install Mage
         run: go install github.com/magefile/mage@v1.15
 
-      - name: Installing quicktype
-        run: |
-          yarn global add quicktype@23
-          echo "$(yarn global bin)" >> $GITHUB_PATH
-
       - name: Build
         run: |
           mage -v build:${{ matrix.target }} ${{ matrix.schema }}

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -50,18 +50,18 @@ func (Build) Ts(schema string) error {
 func (Build) Go(schema string) error {
 	fmt.Printf("⚙️ Generate go types for %s\n", schema)
 
-	ensureQuicktype()
+	ensureGoCodegen()
 
 	_, dest := schemaDestination(schema, GO_DIR)
-
 	if err := os.MkdirAll(dest, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	err := sh.Run("bash", "-c",
-		fmt.Sprintf("quicktype -s schema %s -o %s --lang go --package schema",
-			filepath.Join(SCHEMA_DIR, schema, "*.json"),
-			filepath.Join(dest, "schema.go")))
+	err := sh.Run("go-codegen", "generate",
+		"messages",
+		filepath.Join(SCHEMA_DIR, fmt.Sprintf("%s.json", schema)),
+		"-o", filepath.Join(dest, "schema.go"),
+		"--package-name", "schema")
 	if err != nil {
 		return fmt.Errorf("failed to generate go types: %w", err)
 	}

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -48,6 +48,11 @@ func (Build) Ts(schema string) error {
 
 // Go build go schema for the given contract schema.
 func (Build) Go(schema string) error {
+	if schema == "axone-cognitarium" {
+		fmt.Println("🚪 Skipping axone-cognitarium schema since codegen generation is failing")
+		return nil
+	}
+
 	fmt.Printf("⚙️ Generate go types for %s\n", schema)
 
 	ensureGoCodegen()

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -66,6 +66,16 @@ func (Build) Go(schema string) error {
 		return fmt.Errorf("failed to generate go types: %w", err)
 	}
 
+	fmt.Println("👨‍💻 Generate go client")
+	err = sh.Run("go-codegen", "generate",
+		"query-client",
+		filepath.Join(SCHEMA_DIR, fmt.Sprintf("%s.json", schema)),
+		"-o", filepath.Join(dest, "client.go"),
+		"--package-name", "schema")
+	if err != nil {
+		return fmt.Errorf("failed to generate go client: %w", err)
+	}
+
 	fmt.Println("🔨 Building go")
 	return runInPath(dest, "go", "build")
 }

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -6,4 +6,5 @@ const (
 	GO_DIR     = "go"
 
 	TS_CODEGEN_VERSION = "1.11.1"
+	GO_CODEGEN_VERSION = "0.2.5"
 )

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -138,3 +138,15 @@ func ensureYarn() {
 		panic("yarn is not installed")
 	}
 }
+
+// EnsureGoCodegen ensures that go-codegen is installed, if not it tries to install it.
+func ensureGoCodegen() {
+	if err := sh.Run("go-codegen", "--help"); err == nil {
+		return
+	}
+
+	fmt.Printf("🔨 Installing go-codegen...\n")
+	if err := sh.Run("go", "install", "github.com/srdtrk/go-codegen@0.2.5"); err != nil {
+		panic(fmt.Sprintf("failed to install go-codegen: %v", err))
+	}
+}

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -139,7 +139,7 @@ func ensureGoCodegen() {
 	}
 
 	fmt.Printf("🔨 Installing go-codegen...\n")
-	if err := sh.Run("go", "install", "github.com/srdtrk/go-codegen@v0.2.5"); err != nil {
+	if err := sh.Run("go", "install", fmt.Sprintf("github.com/srdtrk/go-codegen@v%s", GO_CODEGEN_VERSION)); err != nil {
 		panic(fmt.Sprintf("failed to install go-codegen: %v", err))
 	}
 }

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -125,13 +125,6 @@ func ensureTsCodegen() {
 	}
 }
 
-// EnsureQuicktype ensures that quicktype is installed, if not it panics.
-func ensureQuicktype() {
-	if err := sh.Run("quicktype", "--help"); err != nil {
-		panic("quicktype is not installed")
-	}
-}
-
 // EnsureYarn ensures that yarn is installed, if not it panics.
 func ensureYarn() {
 	if err := sh.Run("yarn", "--help"); err != nil {
@@ -146,7 +139,7 @@ func ensureGoCodegen() {
 	}
 
 	fmt.Printf("🔨 Installing go-codegen...\n")
-	if err := sh.Run("go", "install", "github.com/srdtrk/go-codegen@0.2.5"); err != nil {
+	if err := sh.Run("go", "install", "github.com/srdtrk/go-codegen@v0.2.5"); err != nil {
 		panic(fmt.Sprintf("failed to install go-codegen: %v", err))
 	}
 }


### PR DESCRIPTION
This PR introduces the use of the [go-codegen](https://github.com/srdtrk/go-codegen) library to generate Go types from the [Cosmwasm](https://github.com/CosmWasm/cosmwasm) JSON Schema. This change was necessitated due to compatibility issues encountered with [quicktype](https://quicktype.io) when generating the JSON Schema (refer to issue [#9](https://github.com/axone-protocol/axone-contract-schema/issues/9)).

In addition to the Go type generation, this PR also includes the generation of a gRPC client in Go.

**⚠️ DISABLE COGNITARIUM**  
Due to issues with the generation of the `axone-cognitarium` contract, it has been temporarily disabled. This issue needs to be resolved in the `codegen` library or by finding an alternative solution. The exclusion is implemented silently in the build script, allowing the CI matrix to continue functioning for other languages without errors. This temporary measure enables the use of other contracts as libraries and potentially allows for manual generation of the `cognitarium` schema code for Go.

### 🔗 Related fixes

- https://github.com/srdtrk/go-codegen/pull/92
- https://github.com/srdtrk/go-codegen/pull/98: Occurs during the generation of `axone-cognitarium`
- https://github.com/srdtrk/go-codegen/issues/99: The generation process fails when an enum is internally tagged as per the [Serde documentation](https://serde.rs/enum-representations.html#internally-tagged). This issue specifically affects the [Value type](https://github.com/axone-protocol/contracts/blob/5323b5260314ad30ce4220b4aceb10057dccc144/contracts/axone-cognitarium/src/msg.rs#L367) in `axone-cognitarium`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new job `create_release` in the release workflow for streamlined release processes.
	- Added functionality to manage the `go-codegen` dependency, enhancing code generation for Go.

- **Bug Fixes**
	- Removed unnecessary installation steps for the `quicktype` package across workflows, streamlining the build process.

- **Documentation**
	- Updated version handling for the Go code generation tool with the new constant `GO_CODEGEN_VERSION`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->