### PR TITLE
[Ts] ♻️ Replace `quicktype` by `ts-codegen`

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,3 +3,4 @@ reviews:
     - "!go/**/*.go"
     - "!go/**/*.md"
     - "!ts/**/*.md"
+    - "!schema/**/*.json"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: set-matrix
-        run: echo "::set-output name=schema::$(ls schema/ | jq -R -s -c 'split("\n")[:-1]' )"
+        run: echo "::set-output name=schema::$(ls schema/ | jq -R -s -c 'split("\n")[:-1] | map(select(test(".json$") | not))')"
 
   build-target:
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: set-matrix
-        run: echo "::set-output name=schema::$(ls schema/ | jq -R -s -c 'split("\n")[:-1]' )"
+        run: echo "::set-output name=schema::$(ls schema/ | jq -R -s -c 'split("\n")[:-1] | map(select(test(".json$") | not))')"
 
   publish-npm-package:
     runs-on: ubuntu-22.04

--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: set-matrix
-        run: echo "::set-output name=schema::$(ls schema/ | jq -R -s -c 'split("\n")[:-1]' )"
+        run: echo "::set-output name=schema::$(ls schema/ | jq -R -s -c 'split("\n")[:-1] | map(select(test(".json$") | not))')"
 
   build-target:
     runs-on: ubuntu-22.04

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -23,8 +23,7 @@ func (Build) Ts(schema string) error {
 
 	ensureTsCodegen()
 
-	name := strings.TrimPrefix(schema, "axone-")
-	dest := filepath.Join(TS_DIR, fmt.Sprintf("%s-schema", name))
+	name, dest := schemaDestination(schema)
 
 	err := sh.Run("ts-codegen", "generate",
 		"--schema", filepath.Join(SCHEMA_DIR, schema),
@@ -51,8 +50,8 @@ func (Build) Ts(schema string) error {
 func (Build) Go(schema string) error {
 	fmt.Printf("⚙️ Generate go types for %s\n", schema)
 
-	name := strings.TrimPrefix(schema, "axone-")
-	dest := filepath.Join(GO_DIR, fmt.Sprintf("%s-schema", name))
+	_, dest := schemaDestination(schema)
+
 	if err := os.MkdirAll(dest, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
@@ -74,8 +73,13 @@ type Clean mg.Namespace
 func (Clean) Ts(schema string) error {
 	fmt.Printf("🧹 Cleaning generated typescript files for %s\n", schema)
 
-	name := strings.TrimPrefix(schema, "axone-")
-	dest := filepath.Join(TS_DIR, fmt.Sprintf("%s-schema", name))
+	_, dest := schemaDestination(schema)
 
 	return sh.Run("yarn", "--cwd", dest, "clean")
+}
+
+func schemaDestination(schema string) (name string, destination string) {
+	name = strings.TrimPrefix(schema, "axone-")
+	destination = filepath.Join(TS_DIR, fmt.Sprintf("%s-schema", name))
+	return
 }

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -50,6 +50,8 @@ func (Build) Ts(schema string) error {
 func (Build) Go(schema string) error {
 	fmt.Printf("⚙️ Generate go types for %s\n", schema)
 
+	ensureQuicktype()
+
 	_, dest := schemaDestination(schema, GO_DIR)
 
 	if err := os.MkdirAll(dest, os.ModePerm); err != nil {

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -19,8 +19,7 @@ type Build mg.Namespace
 func (Build) Ts(schema string) error {
 	fmt.Printf("⚙️ Generate typescript types for %s\n", schema)
 
-	ensureYarn()
-	ensureQuicktype()
+	ensureTsCodegen()
 
 	name := strings.TrimPrefix(schema, "axone-")
 	dest := filepath.Join(TS_DIR, fmt.Sprintf("%s-schema", name))
@@ -28,10 +27,13 @@ func (Build) Ts(schema string) error {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	err := sh.Run("bash", "-c",
-		fmt.Sprintf("quicktype -s schema %s -o %s --prefer-types --prefer-unions",
-			filepath.Join(SCHEMA_DIR, schema, "*.json"),
-			filepath.Join(dest, "gen-ts", "schema.ts")))
+	err := sh.Run("ts-codegen", "generate",
+		"--schema", filepath.Join(SCHEMA_DIR, schema),
+		"--out", filepath.Join(dest, "gen-ts"),
+		"--typesOnly",
+		"--no-bundle",
+		"--name", schema,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to generate typescript types: %w", err)
 	}

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -17,6 +17,8 @@ type Build mg.Namespace
 
 // Ts build typescript schema for the given contract schema.
 func (Build) Ts(schema string) error {
+	mg.Deps(mg.F(Clean.Ts, schema))
+
 	fmt.Printf("⚙️ Generate typescript types for %s\n", schema)
 
 	ensureTsCodegen()
@@ -68,4 +70,15 @@ func (Build) Go(schema string) error {
 
 	fmt.Println("🔨 Building go")
 	return runInPath(dest, "go", "build")
+}
+
+type Clean mg.Namespace
+
+func (Clean) Ts(schema string) error {
+	fmt.Printf("🧹 Cleaning generated typescript files for %s\n", schema)
+
+	name := strings.TrimPrefix(schema, "axone-")
+	dest := filepath.Join(TS_DIR, fmt.Sprintf("%s-schema", name))
+
+	return sh.Run("yarn", "--cwd", dest, "clean")
 }

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -34,7 +34,7 @@ func (Build) Ts(schema string) error {
 		"--out", filepath.Join(dest, "gen-ts"),
 		"--typesOnly",
 		"--no-bundle",
-		"--name", schema,
+		"--name", name,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to generate typescript types: %w", err)

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -23,7 +23,7 @@ func (Build) Ts(schema string) error {
 
 	ensureTsCodegen()
 
-	name, dest := schemaDestination(schema)
+	name, dest := schemaDestination(schema, TS_DIR)
 
 	err := sh.Run("ts-codegen", "generate",
 		"--schema", filepath.Join(SCHEMA_DIR, schema),
@@ -50,7 +50,7 @@ func (Build) Ts(schema string) error {
 func (Build) Go(schema string) error {
 	fmt.Printf("⚙️ Generate go types for %s\n", schema)
 
-	_, dest := schemaDestination(schema)
+	_, dest := schemaDestination(schema, GO_DIR)
 
 	if err := os.MkdirAll(dest, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
@@ -73,13 +73,13 @@ type Clean mg.Namespace
 func (Clean) Ts(schema string) error {
 	fmt.Printf("🧹 Cleaning generated typescript files for %s\n", schema)
 
-	_, dest := schemaDestination(schema)
+	_, dest := schemaDestination(schema, TS_DIR)
 
 	return sh.Run("yarn", "--cwd", dest, "clean")
 }
 
-func schemaDestination(schema string) (name string, destination string) {
+func schemaDestination(schema, root string) (name string, destination string) {
 	name = strings.TrimPrefix(schema, "axone-")
-	destination = filepath.Join(TS_DIR, fmt.Sprintf("%s-schema", name))
+	destination = filepath.Join(root, fmt.Sprintf("%s-schema", name))
 	return
 }

--- a/magefiles/build.go
+++ b/magefiles/build.go
@@ -25,9 +25,6 @@ func (Build) Ts(schema string) error {
 
 	name := strings.TrimPrefix(schema, "axone-")
 	dest := filepath.Join(TS_DIR, fmt.Sprintf("%s-schema", name))
-	if err := os.MkdirAll(filepath.Join(dest, "gen-ts"), os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create directory: %w", err)
-	}
 
 	err := sh.Run("ts-codegen", "generate",
 		"--schema", filepath.Join(SCHEMA_DIR, schema),

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -4,4 +4,6 @@ const (
 	SCHEMA_DIR = "schema"
 	TS_DIR     = "ts"
 	GO_DIR     = "go"
+
+	TS_CODEGEN_VERSION = "1.11.1"
 )

--- a/magefiles/schema.go
+++ b/magefiles/schema.go
@@ -61,7 +61,7 @@ func (s Schema) Generate(ref string) error {
 
 	fmt.Println("🔨 Moving generated json schema")
 	if err := sh.Run("bash", "-c",
-		fmt.Sprintf("rsync -rmv --include='*/' --include='*/schema/raw/*.json' --exclude='*' %s/contracts/ %s/", CONTRACTS_TMP_DIR, SCHEMA_DIR)); err != nil {
+		fmt.Sprintf("rsync -rmv --include='*/' --include='*/schema/raw/*.json'  --include='*/schema/*.json' --exclude='*' %s/contracts/ %s/", CONTRACTS_TMP_DIR, SCHEMA_DIR)); err != nil {
 		return fmt.Errorf("failed to move generated json schema: %w", err)
 	}
 

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -109,6 +109,22 @@ func ensureCargoMake() {
 	}
 }
 
+// EnsureTsCodegen ensures that ts-codegen is installed, if not, it tries to install it.
+func ensureTsCodegen() {
+	if err := sh.Run("ts-codegen", "help"); err == nil {
+		return
+	}
+
+	ensureYarn()
+
+	fmt.Println("⚠️ ts-codegen not found, installing...")
+	if err := sh.Run("yarn",
+		"global",
+		"add", fmt.Sprintf("@cosmwasm/ts-codegen@%s", TS_CODEGEN_VERSION)); err != nil {
+		panic(fmt.Sprintf("failed to install ts-codegen: %v", err))
+	}
+}
+
 // EnsureQuicktype ensures that quicktype is installed, if not it panics.
 func ensureQuicktype() {
 	if err := sh.Run("quicktype", "--help"); err != nil {

--- a/schema/axone-cognitarium.json
+++ b/schema/axone-cognitarium.json
@@ -1,0 +1,1880 @@
+{
+  "contract_name": "axone-cognitarium",
+  "contract_version": "5.0.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "description": "Instantiate message",
+    "type": "object",
+    "properties": {
+      "limits": {
+        "description": "Limitations regarding store usage.",
+        "default": {
+          "max_byte_size": "340282366920938463463374607431768211455",
+          "max_insert_data_byte_size": "340282366920938463463374607431768211455",
+          "max_insert_data_triple_count": "340282366920938463463374607431768211455",
+          "max_query_limit": 30,
+          "max_query_variable_count": 30,
+          "max_triple_byte_size": "340282366920938463463374607431768211455",
+          "max_triple_count": "340282366920938463463374607431768211455"
+        },
+        "allOf": [
+          {
+            "$ref": "#/definitions/StoreLimitsInput"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "StoreLimitsInput": {
+        "title": "StoreLimitsInput",
+        "description": "Contains requested limitations regarding store usages.",
+        "type": "object",
+        "properties": {
+          "max_byte_size": {
+            "description": "The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. Default to [Uint128::MAX] if not set, which can be considered as no limit.",
+            "default": "340282366920938463463374607431768211455",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              }
+            ]
+          },
+          "max_insert_data_byte_size": {
+            "description": "The maximum number of bytes an insert data query can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.",
+            "default": "340282366920938463463374607431768211455",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              }
+            ]
+          },
+          "max_insert_data_triple_count": {
+            "description": "The maximum number of triples an insert data query can contain (after parsing). Default to [Uint128::MAX] if not set, which can be considered as no limit.",
+            "default": "340282366920938463463374607431768211455",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              }
+            ]
+          },
+          "max_query_limit": {
+            "description": "The maximum limit of a query, i.e. the maximum number of triples returned by a select query. Default to 30 if not set.",
+            "default": 30,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "max_query_variable_count": {
+            "description": "The maximum number of variables a query can select. Default to 30 if not set.",
+            "default": 30,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "max_triple_byte_size": {
+            "description": "The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals. Default to [Uint128::MAX] if not set, which can be considered as no limit.",
+            "default": "340282366920938463463374607431768211455",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              }
+            ]
+          },
+          "max_triple_count": {
+            "description": "The maximum number of triples the store can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.",
+            "default": "340282366920938463463374607431768211455",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "description": "Execute messages",
+    "oneOf": [
+      {
+        "title": "InsertData",
+        "description": "Insert the data as RDF triples in the store. For already existing triples it acts as no-op.\n\nOnly the smart contract owner (i.e. the address who instantiated it) is authorized to perform this action.",
+        "type": "object",
+        "required": [
+          "insert_data"
+        ],
+        "properties": {
+          "insert_data": {
+            "type": "object",
+            "required": [
+              "data"
+            ],
+            "properties": {
+              "data": {
+                "description": "The data to insert. The data must be serialized in the format specified by the `format` field. And the data are subject to the limitations defined by the `limits` specified at contract instantiation.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Binary"
+                  }
+                ]
+              },
+              "format": {
+                "description": "The data format in which the triples are serialized. If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format.",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/DataFormat"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "DeleteData",
+        "description": "Delete the data (RDF triples) from the store matching the patterns defined by the provided query. For non-existing triples it acts as no-op.\n\nExample: ```json { \"prefixes\": [ { \"prefix\": \"foaf\", \"namespace\": \"http://xmlns.com/foaf/0.1/\" } ], \"delete\": [ { \"subject\": { \"variable\": \"s\" }, \"predicate\": { \"variable\": \"p\" }, \"object\": { \"variable\": \"o\" } } ], \"where\": [ { \"simple\": { \"triplePattern\": { \"subject\": { \"variable\": \"s\" }, \"predicate\": { \"namedNode\": {\"prefixed\": \"foaf:givenName\"} }, \"object\": { \"literal\": { \"simple\": \"Myrddin\" } } } } }, { \"simple\": { \"triplePattern\": { \"subject\": { \"variable\": \"s\" }, \"predicate\": { \"variable\": \"p\" }, \"object\": { \"variable\": \"o\" } } } } ] ```\n\nOnly the smart contract owner (i.e. the address who instantiated it) is authorized to perform this action.",
+        "type": "object",
+        "required": [
+          "delete_data"
+        ],
+        "properties": {
+          "delete_data": {
+            "type": "object",
+            "required": [
+              "delete",
+              "prefixes",
+              "where"
+            ],
+            "properties": {
+              "delete": {
+                "description": "Specifies the specific triple templates to delete. If nothing is provided, the patterns from the `where` clause are used for deletion.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/TripleDeleteTemplate"
+                }
+              },
+              "prefixes": {
+                "description": "The prefixes used in the operation.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/Prefix"
+                }
+              },
+              "where": {
+                "description": "Defines the patterns that data (RDF triples) should match in order for it to be considered for deletion.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/WhereCondition"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "DataFormat": {
+        "title": "DataFormat",
+        "description": "Represents the format in which the data are serialized, for example when returned by a query or when inserted in the store.",
+        "oneOf": [
+          {
+            "title": "RDF XML",
+            "description": "Output in [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/) format.",
+            "type": "string",
+            "enum": [
+              "rdf_xml"
+            ]
+          },
+          {
+            "title": "Turtle",
+            "description": "Output in [Turtle](https://www.w3.org/TR/turtle/) format.",
+            "type": "string",
+            "enum": [
+              "turtle"
+            ]
+          },
+          {
+            "title": "N-Triples",
+            "description": "Output in [N-Triples](https://www.w3.org/TR/n-triples/) format.",
+            "type": "string",
+            "enum": [
+              "n_triples"
+            ]
+          },
+          {
+            "title": "N-Quads",
+            "description": "Output in [N-Quads](https://www.w3.org/TR/n-quads/) format.",
+            "type": "string",
+            "enum": [
+              "n_quads"
+            ]
+          }
+        ]
+      },
+      "IRI": {
+        "title": "IRI",
+        "description": "Represents an IRI.",
+        "oneOf": [
+          {
+            "title": "Prefixed",
+            "description": "An IRI prefixed with a prefix. The prefixed IRI is expanded to a full IRI using the prefix definition specified in the query. For example, the prefixed IRI `rdf:type` is expanded to `http://www.w3.org/1999/02/22-rdf-syntax-ns#type`.",
+            "type": "object",
+            "required": [
+              "prefixed"
+            ],
+            "properties": {
+              "prefixed": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Full",
+            "description": "A full IRI.",
+            "type": "object",
+            "required": [
+              "full"
+            ],
+            "properties": {
+              "full": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Literal": {
+        "title": "Literal",
+        "description": "An RDF [literal](https://www.w3.org/TR/rdf11-concepts/#dfn-literal).",
+        "oneOf": [
+          {
+            "title": "Simple",
+            "description": "A [simple literal](https://www.w3.org/TR/rdf11-concepts/#dfn-simple-literal) without datatype or language form.",
+            "type": "object",
+            "required": [
+              "simple"
+            ],
+            "properties": {
+              "simple": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "LanguageTaggedString",
+            "description": "A [language-tagged string](https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string)",
+            "type": "object",
+            "required": [
+              "language_tagged_string"
+            ],
+            "properties": {
+              "language_tagged_string": {
+                "type": "object",
+                "required": [
+                  "language",
+                  "value"
+                ],
+                "properties": {
+                  "language": {
+                    "description": "The [language tag](https://www.w3.org/TR/rdf11-concepts/#dfn-language-tag).",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "The [lexical form](https://www.w3.org/TR/rdf11-concepts/#dfn-lexical-form).",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "TypedValue",
+            "description": "A value with a datatype.",
+            "type": "object",
+            "required": [
+              "typed_value"
+            ],
+            "properties": {
+              "typed_value": {
+                "type": "object",
+                "required": [
+                  "datatype",
+                  "value"
+                ],
+                "properties": {
+                  "datatype": {
+                    "description": "The [datatype IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri).",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/IRI"
+                      }
+                    ]
+                  },
+                  "value": {
+                    "description": "The [lexical form](https://www.w3.org/TR/rdf11-concepts/#dfn-lexical-form).",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Node": {
+        "title": "Node",
+        "description": "Represents either an IRI (named node) or a blank node.",
+        "oneOf": [
+          {
+            "title": "NamedNode",
+            "description": "An RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri).",
+            "type": "object",
+            "required": [
+              "named_node"
+            ],
+            "properties": {
+              "named_node": {
+                "$ref": "#/definitions/IRI"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "BlankNode",
+            "description": "An RDF [blank node](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node).",
+            "type": "object",
+            "required": [
+              "blank_node"
+            ],
+            "properties": {
+              "blank_node": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Prefix": {
+        "title": "Prefix",
+        "description": "Represents a prefix, i.e. a shortcut for a namespace used in a query.",
+        "type": "object",
+        "required": [
+          "namespace",
+          "prefix"
+        ],
+        "properties": {
+          "namespace": {
+            "description": "The namespace associated with the prefix.",
+            "type": "string"
+          },
+          "prefix": {
+            "description": "The prefix.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SimpleWhereCondition": {
+        "title": "SimpleWhereCondition",
+        "description": "Represents a simple condition in a [WhereCondition].",
+        "oneOf": [
+          {
+            "title": "TriplePattern",
+            "description": "Represents a triple pattern, i.e. a condition on a triple based on its subject, predicate and object.",
+            "type": "object",
+            "required": [
+              "triple_pattern"
+            ],
+            "properties": {
+              "triple_pattern": {
+                "$ref": "#/definitions/TriplePattern"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "TripleDeleteTemplate": {
+        "title": "TripleDeleteTemplate",
+        "description": "Represents a triple template to be deleted.",
+        "type": "object",
+        "required": [
+          "object",
+          "predicate",
+          "subject"
+        ],
+        "properties": {
+          "object": {
+            "description": "The object of the triple pattern.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/VarOrNamedNodeOrLiteral"
+              }
+            ]
+          },
+          "predicate": {
+            "description": "The predicate of the triple pattern.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/VarOrNamedNode"
+              }
+            ]
+          },
+          "subject": {
+            "description": "The subject of the triple pattern.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/VarOrNamedNode"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "TriplePattern": {
+        "title": "TriplePattern",
+        "description": "Represents a triple pattern in a [SimpleWhereCondition].",
+        "type": "object",
+        "required": [
+          "object",
+          "predicate",
+          "subject"
+        ],
+        "properties": {
+          "object": {
+            "description": "The object of the triple pattern.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/VarOrNodeOrLiteral"
+              }
+            ]
+          },
+          "predicate": {
+            "description": "The predicate of the triple pattern.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/VarOrNamedNode"
+              }
+            ]
+          },
+          "subject": {
+            "description": "The subject of the triple pattern.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/VarOrNode"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "VarOrNamedNode": {
+        "title": "VarOrNamedNode {",
+        "description": "Represents either a variable or a named node (IRI).",
+        "oneOf": [
+          {
+            "title": "Variable",
+            "description": "A variable.",
+            "type": "object",
+            "required": [
+              "variable"
+            ],
+            "properties": {
+              "variable": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "NamedNode",
+            "description": "An RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri).",
+            "type": "object",
+            "required": [
+              "named_node"
+            ],
+            "properties": {
+              "named_node": {
+                "$ref": "#/definitions/IRI"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "VarOrNamedNodeOrLiteral": {
+        "title": "VarOrNamedNodeOrLiteral",
+        "description": "Represents either a variable, a named node or a literal.",
+        "oneOf": [
+          {
+            "title": "Variable",
+            "description": "A variable.",
+            "type": "object",
+            "required": [
+              "variable"
+            ],
+            "properties": {
+              "variable": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "NamedNode",
+            "description": "An RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri).",
+            "type": "object",
+            "required": [
+              "named_node"
+            ],
+            "properties": {
+              "named_node": {
+                "$ref": "#/definitions/IRI"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Literal",
+            "description": "An RDF [literal](https://www.w3.org/TR/rdf11-concepts/#dfn-literal), i.e. a simple literal, a language-tagged string or a typed value.",
+            "type": "object",
+            "required": [
+              "literal"
+            ],
+            "properties": {
+              "literal": {
+                "$ref": "#/definitions/Literal"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "VarOrNode": {
+        "title": "VarOrNode",
+        "description": "Represents either a variable or a node.",
+        "oneOf": [
+          {
+            "title": "Variable",
+            "description": "A variable.",
+            "type": "object",
+            "required": [
+              "variable"
+            ],
+            "properties": {
+              "variable": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Node",
+            "description": "A node, i.e. an IRI or a blank node.",
+            "type": "object",
+            "required": [
+              "node"
+            ],
+            "properties": {
+              "node": {
+                "$ref": "#/definitions/Node"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "VarOrNodeOrLiteral": {
+        "title": "VarOrNodeOrLiteral",
+        "description": "Represents either a variable, a node or a literal.",
+        "oneOf": [
+          {
+            "title": "Variable",
+            "description": "A variable.",
+            "type": "object",
+            "required": [
+              "variable"
+            ],
+            "properties": {
+              "variable": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Node",
+            "description": "A node, i.e. an IRI or a blank node.",
+            "type": "object",
+            "required": [
+              "node"
+            ],
+            "properties": {
+              "node": {
+                "$ref": "#/definitions/Node"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Literal",
+            "description": "An RDF [literal](https://www.w3.org/TR/rdf11-concepts/#dfn-literal), i.e. a simple literal, a language-tagged string or a typed value.",
+            "type": "object",
+            "required": [
+              "literal"
+            ],
+            "properties": {
+              "literal": {
+                "$ref": "#/definitions/Literal"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "WhereCondition": {
+        "title": "WhereCondition",
+        "description": "Represents a condition in a [WhereClause].",
+        "oneOf": [
+          {
+            "title": "Simple",
+            "description": "Represents a simple condition.",
+            "type": "object",
+            "required": [
+              "simple"
+            ],
+            "properties": {
+              "simple": {
+                "$ref": "#/definitions/SimpleWhereCondition"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "Query messages",
+    "oneOf": [
+      {
+        "title": "Store",
+        "description": "Returns information about the triple store.",
+        "type": "object",
+        "required": [
+          "store"
+        ],
+        "properties": {
+          "store": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "Select",
+        "description": "Returns the resources matching the criteria defined by the provided query.",
+        "type": "object",
+        "required": [
+          "select"
+        ],
+        "properties": {
+          "select": {
+            "type": "object",
+            "required": [
+              "query"
+            ],
+            "properties": {
+              "query": {
+                "description": "The query to execute.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/SelectQuery"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "Describe",
+        "description": "Returns a description of the resource identified by the provided IRI as a set of RDF triples serialized in the provided format.",
+        "type": "object",
+        "required": [
+          "describe"
+        ],
+        "properties": {
+          "describe": {
+            "type": "object",
+            "required": [
+              "query"
+            ],
+            "properties": {
+              "format": {
+                "description": "The format in which the triples are serialized. If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format.",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/DataFormat"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "query": {
+                "description": "The query to execute.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/DescribeQuery"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "Construct",
+        "description": "Returns the resources matching the criteria defined by the provided query as a set of RDF triples serialized in the provided format.",
+        "type": "object",
+        "required": [
+          "construct"
+        ],
+        "properties": {
+          "construct": {
+            "type": "object",
+            "required": [
+              "query"
+            ],
+            "properties": {
+              "format": {
+                "description": "The format in which the triples are serialized. If not provided, the default format is [Turtle](https://www.w3.org/TR/turtle/) format.",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/DataFormat"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "query": {
+                "description": "The query to execute.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/ConstructQuery"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "ConstructQuery": {
+        "title": "ConstructQuery",
+        "description": "Represents a CONSTRUCT query over the triple store, allowing to retrieve a set of triples serialized in a specific format.",
+        "type": "object",
+        "required": [
+          "construct",
+          "prefixes",
+          "where"
+        ],
+        "properties": {
+          "construct": {
+            "description": "The triples to construct. If nothing is provided, the patterns from the `where` clause are used for construction.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/TripleConstructTemplate"
+            }
+          },
+          "prefixes": {
+            "description": "The prefixes used in the query.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Prefix"
+            }
+          },
+          "where": {
+            "description": "The WHERE clause. This clause is used to specify the triples to construct using variable bindings.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/WhereCondition"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "DataFormat": {
+        "title": "DataFormat",
+        "description": "Represents the format in which the data are serialized, for example when returned by a query or when inserted in the store.",
+        "oneOf": [
+          {
+            "title": "RDF XML",
+            "description": "Output in [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/) format.",
+            "type": "string",
+            "enum": [
+              "rdf_xml"
+            ]
+          },
+          {
+            "title": "Turtle",
+            "description": "Output in [Turtle](https://www.w3.org/TR/turtle/) format.",
+            "type": "string",
+            "enum": [
+              "turtle"
+            ]
+          },
+          {
+            "title": "N-Triples",
+            "description": "Output in [N-Triples](https://www.w3.org/TR/n-triples/) format.",
+            "type": "string",
+            "enum": [
+              "n_triples"
+            ]
+          },
+          {
+            "title": "N-Quads",
+            "description": "Output in [N-Quads](https://www.w3.org/TR/n-quads/) format.",
+            "type": "string",
+            "enum": [
+              "n_quads"
+            ]
+          }
+        ]
+      },
+      "DescribeQuery": {
+        "title": "DescribeQuery",
+        "description": "Represents a DESCRIBE query over the triple store, allowing to retrieve a description of a resource as a set of triples serialized in a specific format.",
+        "type": "object",
+        "required": [
+          "prefixes",
+          "resource",
+          "where"
+        ],
+        "properties": {
+          "prefixes": {
+            "description": "The prefixes used in the query.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Prefix"
+            }
+          },
+          "resource": {
+            "description": "The resource to describe given as a variable or a node.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/VarOrNamedNode"
+              }
+            ]
+          },
+          "where": {
+            "description": "The WHERE clause. This clause is used to specify the resource identifier to describe using variable bindings.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/WhereCondition"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "IRI": {
+        "title": "IRI",
+        "description": "Represents an IRI.",
+        "oneOf": [
+          {
+            "title": "Prefixed",
+            "description": "An IRI prefixed with a prefix. The prefixed IRI is expanded to a full IRI using the prefix definition specified in the query. For example, the prefixed IRI `rdf:type` is expanded to `http://www.w3.org/1999/02/22-rdf-syntax-ns#type`.",
+            "type": "object",
+            "required": [
+              "prefixed"
+            ],
+            "properties": {
+              "prefixed": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Full",
+            "description": "A full IRI.",
+            "type": "object",
+            "required": [
+              "full"
+            ],
+            "properties": {
+              "full": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Literal": {
+        "title": "Literal",
+        "description": "An RDF [literal](https://www.w3.org/TR/rdf11-concepts/#dfn-literal).",
+        "oneOf": [
+          {
+            "title": "Simple",
+            "description": "A [simple literal](https://www.w3.org/TR/rdf11-concepts/#dfn-simple-literal) without datatype or language form.",
+            "type": "object",
+            "required": [
+              "simple"
+            ],
+            "properties": {
+              "simple": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "LanguageTaggedString",
+            "description": "A [language-tagged string](https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string)",
+            "type": "object",
+            "required": [
+              "language_tagged_string"
+            ],
+            "properties": {
+              "language_tagged_string": {
+                "type": "object",
+                "required": [
+                  "language",
+                  "value"
+                ],
+                "properties": {
+                  "language": {
+                    "description": "The [language tag](https://www.w3.org/TR/rdf11-concepts/#dfn-language-tag).",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "The [lexical form](https://www.w3.org/TR/rdf11-concepts/#dfn-lexical-form).",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "TypedValue",
+            "description": "A value with a datatype.",
+            "type": "object",
+            "required": [
+              "typed_value"
+            ],
+            "properties": {
+              "typed_value": {
+                "type": "object",
+                "required": [
+                  "datatype",
+                  "value"
+                ],
+                "properties": {
+                  "datatype": {
+                    "description": "The [datatype IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri).",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/IRI"
+                      }
+                    ]
+                  },
+                  "value": {
+                    "description": "The [lexical form](https://www.w3.org/TR/rdf11-concepts/#dfn-lexical-form).",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Node": {
+        "title": "Node",
+        "description": "Represents either an IRI (named node) or a blank node.",
+        "oneOf": [
+          {
+            "title": "NamedNode",
+            "description": "An RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri).",
+            "type": "object",
+            "required": [
+              "named_node"
+            ],
+            "properties": {
+              "named_node": {
+                "$ref": "#/definitions/IRI"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "BlankNode",
+            "description": "An RDF [blank node](https://www.w3.org/TR/rdf11-concepts/#dfn-blank-node).",
+            "type": "object",
+            "required": [
+              "blank_node"
+            ],
+            "properties": {
+              "blank_node": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Prefix": {
+        "title": "Prefix",
+        "description": "Represents a prefix, i.e. a shortcut for a namespace used in a query.",
+        "type": "object",
+        "required": [
+          "namespace",
+          "prefix"
+        ],
+        "properties": {
+          "namespace": {
+            "description": "The namespace associated with the prefix.",
+            "type": "string"
+          },
+          "prefix": {
+            "description": "The prefix.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SelectItem": {
+        "title": "SelectItem",
+        "description": "Represents an item to select in a [SelectQuery].",
+        "oneOf": [
+          {
+            "title": "Variable",
+            "description": "Represents a variable.",
+            "type": "object",
+            "required": [
+              "variable"
+            ],
+            "properties": {
+              "variable": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "SelectQuery": {
+        "title": "SelectQuery",
+        "description": "Represents a SELECT query over the triple store, allowing to select variables to return and to filter the results.",
+        "type": "object",
+        "required": [
+          "prefixes",
+          "select",
+          "where"
+        ],
+        "properties": {
+          "limit": {
+            "description": "The maximum number of results to return. If `None`, there is no limit. Note: the value of the limit cannot exceed the maximum query limit defined in the store limitations.",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "prefixes": {
+            "description": "The prefixes used in the query.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Prefix"
+            }
+          },
+          "select": {
+            "description": "The items to select. Note: the number of items to select cannot exceed the maximum query variable count defined in the store limitations.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/SelectItem"
+            }
+          },
+          "where": {
+            "description": "The WHERE clause. If `None`, there is no WHERE clause, i.e. all triples are returned without filtering.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/WhereCondition"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "SimpleWhereCondition": {
+        "title": "SimpleWhereCondition",
+        "description": "Represents a simple condition in a [WhereCondition].",
+        "oneOf": [
+          {
+            "title": "TriplePattern",
+            "description": "Represents a triple pattern, i.e. a condition on a triple based on its subject, predicate and object.",
+            "type": "object",
+            "required": [
+              "triple_pattern"
+            ],
+            "properties": {
+              "triple_pattern": {
+                "$ref": "#/definitions/TriplePattern"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "TripleConstructTemplate": {
+        "title": "TripleConstructTemplate",
+        "description": "Represents a triple template to be forged for a construct query.",
+        "type": "object",
+        "required": [
+          "object",
+          "predicate",
+          "subject"
+        ],
+        "properties": {
+          "object": {
+            "description": "The object of the triple pattern.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/VarOrNodeOrLiteral"
+              }
+            ]
+          },
+          "predicate": {
+            "description": "The predicate of the triple pattern.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/VarOrNamedNode"
+              }
+            ]
+          },
+          "subject": {
+            "description": "The subject of the triple pattern.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/VarOrNode"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "TriplePattern": {
+        "title": "TriplePattern",
+        "description": "Represents a triple pattern in a [SimpleWhereCondition].",
+        "type": "object",
+        "required": [
+          "object",
+          "predicate",
+          "subject"
+        ],
+        "properties": {
+          "object": {
+            "description": "The object of the triple pattern.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/VarOrNodeOrLiteral"
+              }
+            ]
+          },
+          "predicate": {
+            "description": "The predicate of the triple pattern.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/VarOrNamedNode"
+              }
+            ]
+          },
+          "subject": {
+            "description": "The subject of the triple pattern.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/VarOrNode"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "VarOrNamedNode": {
+        "title": "VarOrNamedNode {",
+        "description": "Represents either a variable or a named node (IRI).",
+        "oneOf": [
+          {
+            "title": "Variable",
+            "description": "A variable.",
+            "type": "object",
+            "required": [
+              "variable"
+            ],
+            "properties": {
+              "variable": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "NamedNode",
+            "description": "An RDF [IRI](https://www.w3.org/TR/rdf11-concepts/#dfn-iri).",
+            "type": "object",
+            "required": [
+              "named_node"
+            ],
+            "properties": {
+              "named_node": {
+                "$ref": "#/definitions/IRI"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "VarOrNode": {
+        "title": "VarOrNode",
+        "description": "Represents either a variable or a node.",
+        "oneOf": [
+          {
+            "title": "Variable",
+            "description": "A variable.",
+            "type": "object",
+            "required": [
+              "variable"
+            ],
+            "properties": {
+              "variable": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Node",
+            "description": "A node, i.e. an IRI or a blank node.",
+            "type": "object",
+            "required": [
+              "node"
+            ],
+            "properties": {
+              "node": {
+                "$ref": "#/definitions/Node"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "VarOrNodeOrLiteral": {
+        "title": "VarOrNodeOrLiteral",
+        "description": "Represents either a variable, a node or a literal.",
+        "oneOf": [
+          {
+            "title": "Variable",
+            "description": "A variable.",
+            "type": "object",
+            "required": [
+              "variable"
+            ],
+            "properties": {
+              "variable": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Node",
+            "description": "A node, i.e. an IRI or a blank node.",
+            "type": "object",
+            "required": [
+              "node"
+            ],
+            "properties": {
+              "node": {
+                "$ref": "#/definitions/Node"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Literal",
+            "description": "An RDF [literal](https://www.w3.org/TR/rdf11-concepts/#dfn-literal), i.e. a simple literal, a language-tagged string or a typed value.",
+            "type": "object",
+            "required": [
+              "literal"
+            ],
+            "properties": {
+              "literal": {
+                "$ref": "#/definitions/Literal"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "WhereCondition": {
+        "title": "WhereCondition",
+        "description": "Represents a condition in a [WhereClause].",
+        "oneOf": [
+          {
+            "title": "Simple",
+            "description": "Represents a simple condition.",
+            "type": "object",
+            "required": [
+              "simple"
+            ],
+            "properties": {
+              "simple": {
+                "$ref": "#/definitions/SimpleWhereCondition"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "construct": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ConstructResponse",
+      "description": "Represents the response of a [QueryMsg::Construct] query.",
+      "type": "object",
+      "required": [
+        "data",
+        "format"
+      ],
+      "properties": {
+        "data": {
+          "description": "The data serialized in the specified format.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Binary"
+            }
+          ]
+        },
+        "format": {
+          "description": "The format of the data.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DataFormat"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "DataFormat": {
+          "title": "DataFormat",
+          "description": "Represents the format in which the data are serialized, for example when returned by a query or when inserted in the store.",
+          "oneOf": [
+            {
+              "title": "RDF XML",
+              "description": "Output in [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/) format.",
+              "type": "string",
+              "enum": [
+                "rdf_xml"
+              ]
+            },
+            {
+              "title": "Turtle",
+              "description": "Output in [Turtle](https://www.w3.org/TR/turtle/) format.",
+              "type": "string",
+              "enum": [
+                "turtle"
+              ]
+            },
+            {
+              "title": "N-Triples",
+              "description": "Output in [N-Triples](https://www.w3.org/TR/n-triples/) format.",
+              "type": "string",
+              "enum": [
+                "n_triples"
+              ]
+            },
+            {
+              "title": "N-Quads",
+              "description": "Output in [N-Quads](https://www.w3.org/TR/n-quads/) format.",
+              "type": "string",
+              "enum": [
+                "n_quads"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "describe": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "DescribeResponse",
+      "description": "Represents the response of a [QueryMsg::Describe] query.",
+      "type": "object",
+      "required": [
+        "data",
+        "format"
+      ],
+      "properties": {
+        "data": {
+          "description": "The data serialized in the specified format.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Binary"
+            }
+          ]
+        },
+        "format": {
+          "description": "The format of the data.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DataFormat"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Binary": {
+          "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+          "type": "string"
+        },
+        "DataFormat": {
+          "title": "DataFormat",
+          "description": "Represents the format in which the data are serialized, for example when returned by a query or when inserted in the store.",
+          "oneOf": [
+            {
+              "title": "RDF XML",
+              "description": "Output in [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/) format.",
+              "type": "string",
+              "enum": [
+                "rdf_xml"
+              ]
+            },
+            {
+              "title": "Turtle",
+              "description": "Output in [Turtle](https://www.w3.org/TR/turtle/) format.",
+              "type": "string",
+              "enum": [
+                "turtle"
+              ]
+            },
+            {
+              "title": "N-Triples",
+              "description": "Output in [N-Triples](https://www.w3.org/TR/n-triples/) format.",
+              "type": "string",
+              "enum": [
+                "n_triples"
+              ]
+            },
+            {
+              "title": "N-Quads",
+              "description": "Output in [N-Quads](https://www.w3.org/TR/n-quads/) format.",
+              "type": "string",
+              "enum": [
+                "n_quads"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "select": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "SelectResponse",
+      "description": "Represents the response of a [QueryMsg::Select] query.",
+      "type": "object",
+      "required": [
+        "head",
+        "results"
+      ],
+      "properties": {
+        "head": {
+          "description": "The head of the response, i.e. the set of variables mentioned in the results.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Head"
+            }
+          ]
+        },
+        "results": {
+          "description": "The results of the select query.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Results"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Head": {
+          "title": "Head",
+          "description": "Represents the head of a [SelectResponse].",
+          "type": "object",
+          "required": [
+            "vars"
+          ],
+          "properties": {
+            "vars": {
+              "description": "The variables selected in the query.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "IRI": {
+          "title": "IRI",
+          "description": "Represents an IRI.",
+          "oneOf": [
+            {
+              "title": "Prefixed",
+              "description": "An IRI prefixed with a prefix. The prefixed IRI is expanded to a full IRI using the prefix definition specified in the query. For example, the prefixed IRI `rdf:type` is expanded to `http://www.w3.org/1999/02/22-rdf-syntax-ns#type`.",
+              "type": "object",
+              "required": [
+                "prefixed"
+              ],
+              "properties": {
+                "prefixed": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "title": "Full",
+              "description": "A full IRI.",
+              "type": "object",
+              "required": [
+                "full"
+              ],
+              "properties": {
+                "full": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Results": {
+          "title": "Results",
+          "description": "Represents the results of a [SelectResponse].",
+          "type": "object",
+          "required": [
+            "bindings"
+          ],
+          "properties": {
+            "bindings": {
+              "description": "The bindings of the results.",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/Value"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "Value": {
+          "title": "Value",
+          "oneOf": [
+            {
+              "title": "URI",
+              "description": "Represents an IRI.",
+              "type": "object",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "uri"
+                  ]
+                },
+                "value": {
+                  "description": "The value of the IRI.",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/IRI"
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "title": "Literal",
+              "description": "Represents a literal S with optional language tag L or datatype IRI D.",
+              "type": "object",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "datatype": {
+                  "description": "The datatype of the literal.",
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/IRI"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "literal"
+                  ]
+                },
+                "value": {
+                  "description": "The value of the literal.",
+                  "type": "string"
+                },
+                "xml:lang": {
+                  "description": "The language tag of the literal.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "title": "BlankNode",
+              "description": "Represents a blank node.",
+              "type": "object",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "blank_node"
+                  ]
+                },
+                "value": {
+                  "description": "The identifier of the blank node.",
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+    "store": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "StoreResponse",
+      "description": "Contains information related to triple store.",
+      "type": "object",
+      "required": [
+        "limits",
+        "owner",
+        "stat"
+      ],
+      "properties": {
+        "limits": {
+          "description": "The store limits.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StoreLimits"
+            }
+          ]
+        },
+        "owner": {
+          "description": "The store owner.",
+          "type": "string"
+        },
+        "stat": {
+          "description": "The store current usage.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StoreStat"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "StoreLimits": {
+          "title": "StoreLimits",
+          "description": "Contains limitations regarding store usages.",
+          "type": "object",
+          "required": [
+            "max_byte_size",
+            "max_insert_data_byte_size",
+            "max_insert_data_triple_count",
+            "max_query_limit",
+            "max_query_variable_count",
+            "max_triple_byte_size",
+            "max_triple_count"
+          ],
+          "properties": {
+            "max_byte_size": {
+              "description": "The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "max_insert_data_byte_size": {
+              "description": "The maximum number of bytes an insert data query can contain.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "max_insert_data_triple_count": {
+              "description": "The maximum number of triples an insert data query can contain (after parsing).",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "max_query_limit": {
+              "description": "The maximum limit of a query, i.e. the maximum number of triples returned by a select query.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "max_query_variable_count": {
+              "description": "The maximum number of variables a query can select.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "max_triple_byte_size": {
+              "description": "The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "max_triple_count": {
+              "description": "The maximum number of triples the store can contain.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "StoreStat": {
+          "title": "StoreStat",
+          "description": "Contains usage information about the triple store.",
+          "type": "object",
+          "required": [
+            "byte_size",
+            "namespace_count",
+            "triple_count"
+          ],
+          "properties": {
+            "byte_size": {
+              "description": "The total triple size in the store, in bytes.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "namespace_count": {
+              "description": "The total number of IRI namespace present in the store.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "triple_count": {
+              "description": "The total number of triple present in the store.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "description": "# Cognitarium\n\nA [CosmWasm](https://cosmwasm.com/) Smart Contract which enables the storage and querying of Semantic data using [RDF (Resource Description Framework)](https://en.wikipedia.org/wiki/Resource_Description_Framework), which represents information as semantic triples.\n\n## Purpose\n\nThe Smart Contract operates as a [semantic database](https://en.wikipedia.org/wiki/Triplestore), adept at storing and fetching [RDF triples](https://en.wikipedia.org/wiki/Semantic_triple) via semantic queries. It can be deployed on any blockchain within the [Cosmos blockchains](https://cosmos.network/) network, utilizing the [CosmWasm](https://cosmwasm.com/) framework.\n\nThe key features of the contract include:\n\n**Insertion of RDF Triples:**\nThis functionality enables the insertion of new data in the form of [RDF triples](https://en.wikipedia.org/wiki/Semantic_triple) onto the blockchain, ensuring secure and tamper-proof storage. The Smart Contract supports inserting these triples in various serialization formats including [RDF/XML](https://en.wikipedia.org/wiki/RDF/XML), [Turtle](https://www.w3.org/TR/turtle/), [N-Triples](https://www.w3.org/TR/n-triples/) and [N-Quads](https://www.w3.org/TR/n-quads/).\n\n**Removal of RDF Triples:**\nThis functionality enables the selective deletion of RDF triples from the on-chain store. Users can specify patterns or criteria that identify the triples to be removed, ensuring precise and targeted removal of data.\n\n**Querying of RDF Triples:**\nThe Smart Contract provides powerful on-chain querying capabilities, allowing users to retrieve specific RDF triples stored on the blockchain. This is done using a variation of [SPARQL](https://www.w3.org/TR/sparql11-query/), a specialized query language designed for retrieving and manipulating data stored in RDF format. Users can specify their search criteria in the query, and the Smart Contract will return the matching RDF triples, directly accessing the on-chain data. This feature supports various serialization formats for the output, such as Turtle, N-Triples, N-Quads, and RDF/XML, offering flexibility in how the retrieved data is presented and used.\n\n**Policies of the Store:**\nThe Smart Contract includes a straightforward yet effective policies functionality to manage the capacity and usage of the on-chain storage effectively. These policies ensure efficient operation and prevent misuse or overuse of the Smart Contract. For instance:\n\n- Maximum Triples: Caps the total number of RDF triples the store can hold, preventing database overload.\n- Storage Size Limit: Sets an upper bound on the store's data size in bytes, managing blockchain resource use.\n- Query Size Limit: Restricts the size or complexity of queries to maintain fast and reliable data retrieval.\n- Insert Data Limit: Limits the size of data (in bytes) that can be added in a single transaction, ensuring smooth and efficient data insertion.\n\n## Rationale\n\nThe data preserved in the blockchain holds significant value due to its derivation from a distributed consensus, rendering it a reliable source for decision-making, applicable to both on-chain and off-chain scenarios.\n\nTo effectively utilize this data, it's essential to adopt representation models that cater to diverse requirements. The Smart Contract Cognitarium provides such a model, facilitating the depiction of intricate and evolving semantic connections within a highly interconnected dataset. This approach transforms the data into a Knowledge Graph, enabling an accurate portrayal of existing facts and fostering the generation of new insights.\n\n## Play\n\n### Model your data with RDF\n\n[RDF](https://www.w3.org/RDF/) encodes information in triple structures. The basic structure of an RDF triple is `subject-predicate-object`, much like a simple sentence in the English language.\n\n1. **Subject**: The subject is the entity or resource the statement is about. It's typically a URI ([Uniform Resource Identifier](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)) which uniquely identifies a resource.\n2. **Predicate**: The predicate (also called a property) is a specific aspect, characteristic, attribute, or relation that describes the subject. It's also typically a URI.\n3. **Object**: The object is the value of the attribute defined by the predicate for the subject. It can be a URI or a literal (such as a string or a number) and may also include additional information such as a language tag or a datatype.\n\nIn RDF, **prefixes** are used as a shorthand notation for long URIs to make the data more readable and less verbose. They're similar to namespaces in programming languages. For instance, instead of writing `http://www.w3.org/2001/XMLSchema#integer`, you could declare a prefix `xsd` to represent the `http://www.w3.org/2001/XMLSchema#` URI and then use `xsd:integer`.\n\n[Turtle (Terse RDF Triple Language)](https://www.w3.org/TR/turtle/) is a syntax that allows RDF to be completely written in a compact and natural text form, with abbreviations for common usage patterns and datatypes.\n\nHere's an RDF triple written in Turtle format (`.ttl` file):\n\n```turtle\n@prefix ex: <http://example.com/stuff/1.0/> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\nex:Alice ex:hasAge \"30\"^^xsd:integer .\n```\n\nIn this example:\n\n- **`ex:Alice`** is the subject (using `ex` as a prefix for the `http://example.com/stuff/1.0/` URI).\n- **`ex:hasAge`** is the predicate.\n- **`\"30\"^^xsd:integer`** is the object, a literal of datatype integer (using **`xsd`** as a prefix for the XML Schema Datatype namespace).\n\nIn the Turtle syntax, the semicolon (**`;`**) is used as a shorthand to reduce verbosity when multiple predicates and objects have the same subject. It allows you to write multiple predicates and objects for the same subject without having to repeat the subject.\nThe comma (**`,`**) is used as a shorthand for reducing verbosity when the same subject and predicate have multiple objects.\n\nSuppose we want to express that Alice is 30 years old person, and her email is `alice@example.com`:\n\n```turtle\n@prefix ex: <http://example.com/stuff/1.0/> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\nex:Alice a <http://www.w3.org/2002/07/owl#Person> ;\n         ex:hasAge \"30\"^^xsd:integer ;\n         ex:hasEmail \"alice@example.com\" .\n```\n\n:::tip\nThe lowercase \"a\" is a special abbreviation for the RDF type property, which states that a resource is an instance of a particular class. This is essentially equivalent to **`<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>`**, and it's used to indicate the type of a resource.\n:::\n\nThe same RDF triple can be expressed in RDF/XML format (`.rdf.xml` file):\n\n```xml\n<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n         xmlns:ex=\"http://example.com/stuff/1.0/\"\n         xmlns:xsd=\"http://www.w3.org/2001/XMLSchema#\">\n  <rdf:Description rdf:about=\"http://example.com/stuff/1.0/Alice\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Person\"/>\n    <ex:hasAge rdf:datatype=\"http://www.w3.org/2001/XMLSchema#integer\">30</ex:hasAge>\n    <ex:hasEmail>alice@example.com</ex:hasEmail>    \n  </rdf:Description>\n</rdf:RDF>\n```\n\n### Instantiate the Smart Contract\n\nLet's initiate a new instance of Smart Contract and input some RDF triples into it. The `axone-cognitarium` can be set up in the following manner. Please consult the schema for additional details regarding configuration settings.\n\n```bash\naxoned tx wasm instantiate $CODE_ID \\\n    --from $ADDR \\\n    --label \"my-rdf-storage\" \\\n    --admin $ADMIN_ADDR \\\n    --gas 1000000 \\\n    '{}'\n```\n\n:::tip\nYou can provide some limitation parameters to restrict usage for both execute and query messages. For instance, you can set a maximum number of triples that can be stored in the smart contract, or a maximum size of data that can be inserted in a single transaction.\n\nThe default values are:\n\n```json\n{ \n  \"limits\": {\n\t\t  \"max_byte_size\": \"340282366920938463463374607431768211455\",\n\t\t  \"max_insert_data_byte_size\": \"340282366920938463463374607431768211455\",\n\t\t  \"max_insert_data_triple_count\": \"340282366920938463463374607431768211455\",\n\t\t  \"max_query_limit\": 30,\n\t\t  \"max_query_variable_count\": 30,\n\t\t  \"max_triple_byte_size\": \"340282366920938463463374607431768211455\",\n\t\t  \"max_triple_count\": \"340282366920938463463374607431768211455\"\n\t}\n}\n```\n\n:::\n\n### Insert RDF triples\n\nTo insert RDF triples, you need to send an `InsertData` message through the `cognitarium` smart contract you've already instantiated. For this operation, your inputs should include the data of the triples, encoded in [base64](https://en.wikipedia.org/wiki/Base64), as well as the format. The format options available are:\n\n- `turtle` (default)\n- `rdf_xml`\n- `n_triples`\n- `n_quads`\n\nLet's consider the following example of data in Turtle format, contained within a file named `data.ttl`. It describes a small network of people and their relationships, such as name, title, and whom they know.\n\n```turtle\n@prefix : <http://example.org/> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix schema: <http://schema.org/> .\n\n:alice a foaf:Person ;\n  foaf:name \"Alice\" ;\n  foaf:knows :bob ;\n  schema:email \"alice@example.org\" .\n\n:bob a foaf:Person ;\n  foaf:name \"Bob\" ;\n  foaf:knows :alice, :carol ;\n  schema:jobTitle \"Software Developer\" .\n\n:carol a foaf:Person ;\n  foaf:name \"Carol\" ;\n  schema:jobTitle \"Data Scientist\" ;\n  foaf:knows :bob .\n```\n\nYou can insert this data into the `cognitarium` smart contract with the following command:\n\n```bash\naxoned tx wasm execute $CONTRACT_ADDR \\\n    --from axone1cu9wzlcyyxpek20jaqfwzu3llzjgx34cqf94yj \\\n    --gas 10000000 \\\n    \"{\\\"insert_data\\\":{\\\"format\\\": \\\"turtle\\\", \\\"data\\\": \\\"$(cat data.ttl | base64 | tr -d '\\n\\r')\\\"}}\"\n```\n\nWith the transaction hash we can query the number of triples inserted:\n\n```bash\naxoned query tx $TX_HASH -ojson | \n    jq -r '.events[] | select(.type == \"wasm\") | .attributes[] | select(.key == \"triple_count\") | .value'\n```\n\n### Query RDF triples\n\nNow that we've populated the axone-cognitarium with several triples, let's explore how to retrieve this data. We can utilize the Select query message for this purpose. If you're familiar with [SPARQL](https://www.w3.org/TR/rdf-sparql-query/), you'll find the process quite intuitive.\n\nA `select` query on a `cognitarium` instance enables you to fetch and filter the data. The `select.query` JSON should contain the following:\n\n- `prefixes` array: to declare a `prefix` and its related `namespace`\n- `limit`: the number of elements to return\n- `where`: filters and variable declarations\n- `select` array: all `variable` names you declared in `where` you want to get\n\n`where` should be an array of elements specifying triple filterings. You have to specify `subject`, `predicate` and `object` as a `variable`, or, alternatively, a `prefixed` or `full` `named_node`.\n\n`object` can also be a `simple` `literal`.\n\nThe following query will select all the triples `subject`, `predicate` and `object` from the store:\n\n```json\n{\n    \"select\": {\n        \"query\": {\n            \"prefixes\": [],\n            \"select\": [\n                {\n                    \"variable\": \"subject\"\n                },\n                {\n                    \"variable\": \"predicate\"\n                },\n                {\n                    \"variable\": \"object\"\n                }\n            ],\n            \"where\": [\n                {\n                    \"simple\": {\n                        \"triple_pattern\": {\n                            \"subject\": {\n                                \"variable\": \"subject\"\n                            },\n                            \"predicate\": {\n                                \"variable\": \"predicate\"\n                            },\n                            \"object\": {\n                                \"variable\": \"object\"\n                            }\n                        }\n                    }\n                }\n            ],\n            \"limit\": null\n        }\n    }\n}\n```\n\nIt's semantically equivalent to the following SPARQL query:\n\n```sparql\nSELECT ?subject ?predicate ?object\nWHERE {\n    ?subject ?predicate ?object\n}\n```\n\nThis query can be executed on the cognitarium smart contract using the command below:\n\n```bash\naxoned query wasm contract-state smart $CONTRACT_ADDR \\\n    '{\"select\":{\"query\":{\"prefixes\":[],\"select\":[{\"variable\":\"subject\"},{\"variable\":\"predicate\"},{\"variable\":\"object\"}],\"where\":[{\"simple\":{\"triple_pattern\":{\"subject\":{\"variable\":\"subject\"},\"predicate\":{\"variable\":\"predicate\"},\"object\":{\"variable\":\"object\"}}}}],\"limit\":null}}}'\n```\n\nNow, let's try something more interresting. Let's retrieve the names of people and their job titles, but only for those who know at least one other person in the network. This query introduces filtering based on relationships.\n\nHere's the query:\n\n```json\n{\n    \"select\": {\n        \"query\": {\n            \"prefixes\": [\n                { \"foaf\": \"http://xmlns.com/foaf/0.1/\" },\n                { \"schema\": \"http://schema.org/\" }\n            ],\n            \"select\": [\n                {\n                    \"variable\": \"personName\"\n                },\n                {\n                    \"variable\": \"jobTitle\"\n                }\n            ],\n            \"where\": [\n                {\n                    \"simple\": {\n                        \"triple_pattern\": {\n                            \"subject\": {\n                                \"variable\": \"person\"\n                            },\n                            \"predicate\": {\n                              \"node\": {\n                                \"named_node\": {\n                                  \"full\": \"http://www.w3.org/1999/02/22-rdf-syntax-ns#type\"\n                                }\n                              }\n                            },\n                            \"object\": {\n                                \"node\": {\n                                    \"named_node\": {\n                                        \"prefixed\": \"foaf:Person\"\n                                    }\n                                }\n                            }\n                        }\n                    }\n                },\n                {\n                    \"simple\": {\n                        \"triple_pattern\": {\n                            \"subject\": {\n                                \"variable\": \"person\"\n                            },\n                            \"predicate\": {\n                                \"node\": {\n                                    \"named_node\": {\n                                        \"prefixed\": \"foaf:Name\"\n                                    }\n                                }\n                            },\n                            \"object\": {\n                                \"variable\": \"personName\"\n                            }\n                        }\n                    }\n                },\n                {\n                    \"simple\": {\n                        \"triple_pattern\": {\n                            \"subject\": {\n                                \"variable\": \"person\"\n                            },\n                            \"predicate\": {\n                                \"node\": {\n                                    \"named_node\": {\n                                        \"prefixed\": \"schema:jobTitle\"\n                                    }\n                                }\n                            },\n                            \"object\": {\n                                \"variable\": \"jobTitle\"\n                            }\n                        }\n                    }\n                },\n                {\n                    \"simple\": {\n                        \"triple_pattern\": {\n                            \"subject\": {\n                                \"variable\": \"person\"\n                            },\n                            \"predicate\": {\n                                \"node\": {\n                                    \"named_node\": {\n                                        \"prefixed\": \"foaf:knows\"\n                                    }\n                                }\n                            },\n                            \"object\": {\n                                \"variable\": \"knownPerson\"\n                            }\n                        }\n                    }\n                }\n            ],\n            \"limit\": null\n        }\n    }\n}\n```\n\nIt's semantically equivalent to the following SPARQL query:\n\n```sparql\nPREFIX foaf: <http://xmlns.com/foaf/0.1/>\nPREFIX schema: <http://schema.org/>\n\nSELECT ?personName ?jobTitle\nWHERE {\n  ?person a foaf:Person .\n  ?person foaf:name ?personName .\n  ?person schema:jobTitle ?jobTitle .\n  ?person foaf:knows ?knownPerson .\n}\n```\n\nThis query can be executed on the cognitarium smart contract using the command below:\n\n```bash\naxoned query wasm contract-state smart $CONTRACT_ADDR \\\n    '{\"select\":{\"query\":{\"prefixes\":[{\"foaf\":\"http://xmlns.com/foaf/0.1/\"},{\"schema\":\"http://schema.org/\"}],\"select\":[{\"variable\":\"personName\"},{\"variable\":\"jobTitle\"}],\"where\":[{\"simple\":{\"triple_pattern\":{\"subject\":{\"variable\":\"person\"},\"predicate\":{\"node\":{\"named_node\":{\"full\":\"http://www.w3.org/1999/02/22-rdf-syntax-ns#type\"}}},\"object\":{\"node\":{\"named_node\":{\"prefixed\":\"foaf:Person\"}}}}}},{\"simple\":{\"triple_pattern\":{\"subject\":{\"variable\":\"person\"},\"predicate\":{\"node\":{\"named_node\":{\"prefixed\":\"foaf:Name\"}}},\"object\":{\"variable\":\"personName\"}}}},{\"simple\":{\"triple_pattern\":{\"subject\":{\"variable\":\"person\"},\"predicate\":{\"node\":{\"named_node\":{\"prefixed\":\"schema:jobTitle\"}}},\"object\":{\"variable\":\"jobTitle\"}}}},{\"simple\":{\"triple_pattern\":{\"subject\":{\"variable\":\"person\"},\"predicate\":{\"node\":{\"named_node\":{\"prefixed\":\"foaf:knows\"}}},\"object\":{\"variable\":\"knownPerson\"}}}}],\"limit\":null}}}'\n```",
+  "title": "axone-cognitarium"
+}

--- a/schema/axone-dataverse.json
+++ b/schema/axone-dataverse.json
@@ -1,0 +1,298 @@
+{
+  "contract_name": "axone-dataverse",
+  "contract_version": "5.0.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "description": "`InstantiateMsg` is used to initialize a new instance of the dataverse.",
+    "type": "object",
+    "required": [
+      "name",
+      "triplestore_config"
+    ],
+    "properties": {
+      "name": {
+        "description": "A unique name to identify the dataverse instance.",
+        "type": "string"
+      },
+      "triplestore_config": {
+        "description": "The configuration used to instantiate the triple store.",
+        "allOf": [
+          {
+            "$ref": "#/definitions/TripleStoreConfig"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "TripleStoreConfig": {
+        "title": "TripleStoreConfig",
+        "description": "`TripleStoreConfig` represents the configuration related to the management of the triple store.",
+        "type": "object",
+        "required": [
+          "code_id",
+          "limits"
+        ],
+        "properties": {
+          "code_id": {
+            "description": "The code id that will be used to instantiate the triple store contract in which to store dataverse semantic data. It must implement the cognitarium interface.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Uint64"
+              }
+            ]
+          },
+          "limits": {
+            "description": "Limitations regarding triple store usage.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/TripleStoreLimitsInput"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "TripleStoreLimitsInput": {
+        "title": "TripleStoreLimitsInput",
+        "description": "Contains requested limitations regarding store usages.",
+        "type": "object",
+        "properties": {
+          "max_byte_size": {
+            "description": "The maximum number of bytes the store can contain. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. Default to [Uint128::MAX] if not set, which can be considered as no limit.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_insert_data_byte_size": {
+            "description": "The maximum number of bytes an insert data query can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_insert_data_triple_count": {
+            "description": "The maximum number of triples an insert data query can contain (after parsing). Default to [Uint128::MAX] if not set, which can be considered as no limit.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_query_limit": {
+            "description": "The maximum limit of a query, i.e. the maximum number of triples returned by a select query. Default to 30 if not set.",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "max_query_variable_count": {
+            "description": "The maximum number of variables a query can select. Default to 30 if not set.",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "max_triple_byte_size": {
+            "description": "The maximum number of bytes the store can contain for a single triple. The size of a triple is counted as the sum of the size of its subject, predicate and object, including the size of data types and language tags if any. The limit is used to prevent storing very large triples, especially literals. Default to [Uint128::MAX] if not set, which can be considered as no limit.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_triple_count": {
+            "description": "The maximum number of triples the store can contain. Default to [Uint128::MAX] if not set, which can be considered as no limit.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "description": "`ExecuteMsg` defines the set of possible actions that can be performed on the dataverse.\n\nThis enum provides variants for registering services, datasets, and other operations related to the dataverse.",
+    "oneOf": [
+      {
+        "title": "SubmitClaims",
+        "description": "Submits new claims about a resource to the dataverse.\n\nThe SubmitClaims message is a pivotal component in the dataverse, enabling entities to contribute new claims about various resources. A claim represents a statement made by an entity, referred to as the issuer, which could be a person, organization, or service. These claims pertain to a diverse range of resources, including digital resources, services, zones, or individuals, and are asserted as factual by the issuer.\n\n#### Format\n\nClaims are injected into the dataverse through Verifiable Credentials (VCs).\n\nPrimarily, the claims leverage the AXONE ontology, which facilitates articulating assertions about widely acknowledged resources in the dataverse, including digital services, digital resources, zones, governance, and more.\n\nAdditionally, other schemas may also be employed to supplement and enhance the validated knowledge contributed to these resources.\n\n#### Preconditions\n\nTo maintain integrity and coherence in the dataverse, several preconditions are set for the submission of claims:\n\n1. **Format Requirement**: Claims must be encapsulated within Verifiable Credentials (VCs).\n\n2. **Unique Identifier Mandate**: Each Verifiable Credential within the dataverse must possess a unique identifier.\n\n3. **Issuer Signature**: Claims must bear the issuer's signature. This signature must be verifiable, ensuring authenticity and credibility.\n\n4. **Content**: The actual implementation supports the submission of a single Verifiable Credential, containing a single claim.\n\n#### Supported cryptographic proofs\n\n- `Ed25519Signature2018`\n\n- `Ed25519Signature2020`\n\n- `EcdsaSecp256k1Signature2019`\n\n- `DataIntegrity` with the following cryptosuites: `eddsa-2022`, `eddsa-rdfc-2022`.",
+        "type": "object",
+        "required": [
+          "submit_claims"
+        ],
+        "properties": {
+          "submit_claims": {
+            "type": "object",
+            "required": [
+              "metadata"
+            ],
+            "properties": {
+              "format": {
+                "description": "RDF dataset serialization format for the metadata. If not provided, the default format is [N-Quads](https://www.w3.org/TR/n-quads/) format.",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/RdfDatasetFormat"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "metadata": {
+                "description": "The serialized metadata intended for attachment. This metadata should adhere to the format specified in the `format` field.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Binary"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "RevokeClaims",
+        "description": "Revoke or withdraw a previously submitted claims.\n\n#### Preconditions:\n\n1. **Identifier Existance**: The identifier of the claims must exist in the dataverse.",
+        "type": "object",
+        "required": [
+          "revoke_claims"
+        ],
+        "properties": {
+          "revoke_claims": {
+            "type": "object",
+            "required": [
+              "identifier"
+            ],
+            "properties": {
+              "identifier": {
+                "description": "The unique identifier of the claims to be revoked.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "RdfDatasetFormat": {
+        "title": "RdfDatasetFormat",
+        "description": "Represents the various serialization formats for an RDF dataset, i.e. a collection of RDF graphs ([RDF Dataset](https://www.w3.org/TR/rdf11-concepts/#section-dataset)).",
+        "oneOf": [
+          {
+            "title": "NQuads",
+            "description": "N-Quads Format\n\nN-Quads is an extension of N-Triples to support RDF datasets by adding an optional fourth element to represent the graph name. See the [official N-Quads specification](https://www.w3.org/TR/n-quads/).",
+            "type": "string",
+            "enum": [
+              "n_quads"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "`QueryMsg` defines the set of possible queries that can be made to retrieve information about the dataverse.\n\nThis enum provides variants for querying the dataverse's details and other related information.",
+    "oneOf": [
+      {
+        "title": "Dataverse",
+        "description": "Retrieves information about the current dataverse instance.",
+        "type": "object",
+        "required": [
+          "dataverse"
+        ],
+        "properties": {
+          "dataverse": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "dataverse": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "DataverseResponse",
+      "description": "DataverseResponse is the response of the Dataverse query.",
+      "type": "object",
+      "required": [
+        "name",
+        "triplestore_address"
+      ],
+      "properties": {
+        "name": {
+          "description": "The name of the dataverse.",
+          "type": "string"
+        },
+        "triplestore_address": {
+          "description": "The cognitarium contract address.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "description": "# Dataverse\n\n## Overview\n\nThe `dataverse` smart contract is responsible for overseeing and managing the Dataverse.\n\n## Dataverse\n\nThe Dataverse is an ever-expanding universe that encompasses a wide range of digital resources. These include datasets, data processing algorithms, ML algorithm, storage resources, computational resources, identity management solutions, orchestration engines, oracles, and many other resources recorded on the blockchain.\n\nWhen the smart contract is instantiated, it creates a Dataverse instance. This instance is separated and isolated from any pre-existing ones, and as many dataverse instances as required can be created.\n\n## Zones\n\nZones within the Dataverse represent distinct areas or domains where specific governance rules and policies are applied. These Zones are conceptual frameworks created to manage and organize resources under a unified set of regulations and permissions.\n\nEach Zone is defined by its unique identity and set of governing rules, which dictate how resources within it can be accessed, used, and shared. This approach allows for granular control over different segments of the Dataverse, catering to various requirements and use cases. By managing these Zones, the dataverse smart contract ensures that resources are utilized in compliance with the defined policies and consents, thereby maintaining order and integrity within the Dataverse.\n\n## Resources\n\nIn the context of the Dataverse, Resources refer to a broad category of digital entities, which include Services and Digital Resources.\n\n- **Digital Resources**: This category extends to various digital entities such as datasets, algorithms, machine learning models, and other digital assets. Like Services, Digital Resources are identified by a URI in conjunction with the Service responsible for their provision.\n\n- **Services**: These are network-accessible functionalities like REST APIs, gRPC services, and other similar offerings. Each Service in the Dataverse is uniquely identified by its Uniform Resource Identifier (URI) and is associated with a specific Registrar responsible for its registration and management.\n\n## Decentralized Identifiers (DID)\n\nDecentralized Identifiers (DID) are a foundational element in the Dataverse, serving as unique, persistent, and globally resolvable identifiers that are fully under the control of the DID subject, which could be an individual, organization, or a any kind of resource (dataset,\nalgorithm, nft, ML algorithm).\n\nDIDs play a crucial role in the Dataverse by facilitating a trustable and interoperable identity mechanism. They enable the establishment of a verifiable and self-sovereign identity for resources, services, and entities within the ecosystem.\n\n## Claims\n\nClaims in the Dataverse context are assertions or statements made about a Resource identified by a DID.\n\nClaims play a pivotal role in the governance framework of the Dataverse. By leveraging knowledge derived from verifiable credentials, the governances established by Zones can evaluate the fulfilment of specific rules and compliance. This evaluation is critical in ensuring that the resources within the Dataverse adhere to the established norms, policies, and requirements.\n\nClaims are submitted in the form of [Verifiable Presentations (VPs)](https://www.w3.org/TR/vc-data-model/#presentations), which are aggregations of one or more [Verifiable Credentials (VCs)](https://www.w3.org/TR/vc-data-model/#what-is-a-verifiable-credential).\n\n## Dependencies\n\nGiven its role and status, this smart contract serves as the primary access point for the AXONE protocol to manage all on-chain stored resources. To fulfill its tasks, the smart contract relies on other smart contracts within the AXONE ecosystem. Notably, it uses the `Cognitarium` smart contract for persisting the Dataverse representation in an ontological form and the `Law Stone` smart contract to establish governance rules.",
+  "title": "axone-dataverse"
+}

--- a/schema/axone-law-stone.json
+++ b/schema/axone-law-stone.json
@@ -1,0 +1,250 @@
+{
+  "contract_name": "axone-law-stone",
+  "contract_version": "5.0.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "description": "Instantiate message",
+    "type": "object",
+    "required": [
+      "program",
+      "storage_address"
+    ],
+    "properties": {
+      "program": {
+        "description": "The Prolog program carrying law rules and facts.",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Binary"
+          }
+        ]
+      },
+      "storage_address": {
+        "description": "The `axone-objectarium` contract address on which to store the law program.",
+        "type": "string"
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "description": "Execute messages",
+    "oneOf": [
+      {
+        "title": "BreakStone",
+        "description": "Break the stone making this contract unusable, by clearing all the related resources: - Unpin all the pinned objects on `axone-objectarium` contracts, if any. - Forget the main program (i.e. or at least unpin it).\n\nOnly the creator address (the address that instantiated the contract) is authorized to invoke this message. If already broken, this is a no-op.",
+        "type": "object",
+        "required": [
+          "break_stone"
+        ],
+        "properties": {
+          "break_stone": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "Query messages",
+    "oneOf": [
+      {
+        "title": "Ask",
+        "description": "Submits a Prolog query string to the `Logic` module, evaluating it against the law program associated with this contract.\n\nIf the law stone is broken the query returns a response with the error `error(system_error(broken_law_stone),root)` set in the `answer` field.",
+        "type": "object",
+        "required": [
+          "ask"
+        ],
+        "properties": {
+          "ask": {
+            "type": "object",
+            "required": [
+              "query"
+            ],
+            "properties": {
+              "query": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "Program",
+        "description": "Retrieves the location metadata of the law program bound to this contract.\n\nThis includes the contract address of the `objectarium` and the program object ID, where the law program's code can be accessed.",
+        "type": "object",
+        "required": [
+          "program"
+        ],
+        "properties": {
+          "program": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "ProgramCode",
+        "description": "Fetches the raw code of the law program tied to this contract.\n\nIf the law stone is broken, the query may fail if the program is no longer available in the `Objectarium`.",
+        "type": "object",
+        "required": [
+          "program_code"
+        ],
+        "properties": {
+          "program_code": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "ask": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "AskResponse",
+      "type": "object",
+      "required": [
+        "gas_used",
+        "height"
+      ],
+      "properties": {
+        "answer": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Answer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "gas_used": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "height": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "user_output": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "definitions": {
+        "Answer": {
+          "type": "object",
+          "required": [
+            "has_more",
+            "results",
+            "variables"
+          ],
+          "properties": {
+            "has_more": {
+              "type": "boolean"
+            },
+            "results": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Result"
+              }
+            },
+            "variables": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "Result": {
+          "type": "object",
+          "required": [
+            "substitutions"
+          ],
+          "properties": {
+            "error": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "substitutions": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Substitution"
+              }
+            }
+          }
+        },
+        "Substitution": {
+          "type": "object",
+          "required": [
+            "expression",
+            "variable"
+          ],
+          "properties": {
+            "expression": {
+              "type": "string"
+            },
+            "variable": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "program": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ProgramResponse",
+      "description": "ProgramResponse carry elements to locate the program in a `axone-objectarium` contract.",
+      "type": "object",
+      "required": [
+        "object_id",
+        "storage_address"
+      ],
+      "properties": {
+        "object_id": {
+          "description": "The program object id in the `axone-objectarium` contract.",
+          "type": "string"
+        },
+        "storage_address": {
+          "description": "The `axone-objectarium` contract address on which the law program is stored.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "program_code": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Binary",
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    }
+  },
+  "description": "# Law Stone\n\n## Overview\n\nThe `axone-law-stone` smart contract aims to provide GaaS (i.e. Governance as a Service) in any [Cosmos blockchains](https://cosmos.network/) using the [CosmWasm](https://cosmwasm.com/) framework and the [Logic](https://docs.axone.xyz/modules/next/logic) AXONE module.\n\nThis contract is built around a Prolog program describing the law by rules and facts. The law stone is immutable, this means it can only be questioned, there are no update mechanisms.\n\nThe `axone-law-stone` responsibility is to guarantee the availability of its rules in order to question them, but not to ensure the rules application.\n\nTo ensure reliability over time, the associated Prolog program is stored and pinned in a `axone-objectarium` contract. Moreover, all the eventual loaded files must be stored in a `axone-objectarium` contract as well, allowing the contract to pin them.\n\nTo be able to free the underlying resources (i.e. objects in `axone-objectarium`) if not used anymore, the contract admin can break the stone.\n\n➡️ Checkout the [examples](https://github.com/axone-protocol/contracts/tree/main/contracts/axone-law-stone/examples/) for usage information.",
+  "title": "axone-law-stone"
+}

--- a/schema/axone-objectarium.json
+++ b/schema/axone-objectarium.json
@@ -1,0 +1,1102 @@
+{
+  "contract_name": "axone-objectarium",
+  "contract_version": "5.0.0",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "description": "Instantiate messages",
+    "type": "object",
+    "required": [
+      "bucket"
+    ],
+    "properties": {
+      "bucket": {
+        "description": "The name of the bucket. The name could not be empty or contains whitespaces. If name contains whitespace, they will be removed.",
+        "type": "string"
+      },
+      "config": {
+        "description": "The configuration of the bucket.",
+        "default": {
+          "accepted_compression_algorithms": [
+            "passthrough",
+            "snappy",
+            "lzma"
+          ],
+          "hash_algorithm": "sha256"
+        },
+        "allOf": [
+          {
+            "$ref": "#/definitions/BucketConfig"
+          }
+        ]
+      },
+      "limits": {
+        "description": "The limits of the bucket.",
+        "default": {
+          "max_object_pins": null,
+          "max_object_size": null,
+          "max_objects": null,
+          "max_total_size": null
+        },
+        "allOf": [
+          {
+            "$ref": "#/definitions/BucketLimits"
+          }
+        ]
+      },
+      "pagination": {
+        "description": "The configuration for paginated query.",
+        "default": {
+          "default_page_size": 10,
+          "max_page_size": 30
+        },
+        "allOf": [
+          {
+            "$ref": "#/definitions/PaginationConfig"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "definitions": {
+      "BucketConfig": {
+        "description": "BucketConfig is the type of the configuration of a bucket.\n\nThe configuration is set at the instantiation of the bucket, and is immutable and cannot be changed. The configuration is optional and if not set, the default configuration is used.",
+        "type": "object",
+        "properties": {
+          "accepted_compression_algorithms": {
+            "description": "The acceptable compression algorithms for the objects in the bucket. If this parameter is not set, then all compression algorithms are accepted. If this parameter is set, then only the compression algorithms in the array are accepted.\n\nWhen an object is stored in the bucket without a specified compression algorithm, the first algorithm in the array is used. Therefore, the order of the algorithms in the array is significant. Typically, the most efficient compression algorithm, such as the NoCompression algorithm, should be placed first in the array.\n\nAny attempt to store an object using a different compression algorithm than the ones specified here will fail.",
+            "default": [
+              "passthrough",
+              "snappy",
+              "lzma"
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/CompressionAlgorithm"
+            }
+          },
+          "hash_algorithm": {
+            "description": "The algorithm used to hash the content of the objects to generate the id of the objects. The algorithm is optional and if not set, the default algorithm is used.\n\nThe default algorithm is Sha256 if not set.",
+            "default": "sha256",
+            "allOf": [
+              {
+                "$ref": "#/definitions/HashAlgorithm"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "BucketLimits": {
+        "description": "BucketLimits is the type of the limits of a bucket.\n\nThe limits are optional and if not set, there is no limit.",
+        "type": "object",
+        "properties": {
+          "max_object_pins": {
+            "description": "The maximum number of pins in the bucket for an object.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_object_size": {
+            "description": "The maximum size of the objects in the bucket.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_objects": {
+            "description": "The maximum number of objects in the bucket.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_total_size": {
+            "description": "The maximum total size of the objects in the bucket.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Uint128"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "CompressionAlgorithm": {
+        "description": "CompressionAlgorithm is an enumeration that defines the different compression algorithms supported for compressing the content of objects. The compression algorithm specified here are relevant algorithms for compressing data on-chain, which means that they are fast to compress and decompress, and have a low computational cost.\n\nThe order of the compression algorithms is based on their estimated computational cost (quite opinionated) during both compression and decompression, ranging from the lowest to the highest. This particular order is utilized to establish the default compression algorithm for storing an object.",
+        "oneOf": [
+          {
+            "title": "Passthrough",
+            "description": "Represents no compression algorithm. The object is stored as is without any compression.",
+            "type": "string",
+            "enum": [
+              "passthrough"
+            ]
+          },
+          {
+            "title": "Snappy",
+            "description": "Represents the Snappy algorithm. Snappy is a compression/decompression algorithm that does not aim for maximum compression. Instead, it aims for very high speeds and reasonable compression.\n\nSee [the snappy web page](https://google.github.io/snappy/) for more information.",
+            "type": "string",
+            "enum": [
+              "snappy"
+            ]
+          },
+          {
+            "title": "Lzma",
+            "description": "Represents the LZMA algorithm. LZMA is a lossless data compression/decompression algorithm that features a high compression ratio and a variable compression-dictionary size up to 4 GB.\n\nSee [the LZMA wiki page](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm) for more information.",
+            "type": "string",
+            "enum": [
+              "lzma"
+            ]
+          }
+        ]
+      },
+      "HashAlgorithm": {
+        "description": "HashAlgorithm is an enumeration that defines the different hash algorithms supported for hashing the content of objects.",
+        "oneOf": [
+          {
+            "title": "MD5",
+            "description": "Represents the MD5 algorithm. MD5 is a widely used cryptographic hash function that produces a 128-bit hash value. The computational cost of MD5 is relatively low compared to other hash functions, but its short hash length makes it easier to find hash collisions. It is now considered insecure for cryptographic purposes, but can still used in non-security contexts.\n\nMD5 hashes are stored on-chain as 32 hexadecimal characters.\n\nSee [the MD5 Wikipedia page](https://en.wikipedia.org/wiki/MD5) for more information.",
+            "type": "string",
+            "enum": [
+              "m_d5"
+            ]
+          },
+          {
+            "title": "SHA1",
+            "description": "Represents the SHA-224 algorithm. SHA-224 is a variant of the SHA-2 family of hash functions that produces a 224-bit hash value. It is similar to SHA-256, but with a shorter output size. The computational cost of SHA-224 is moderate, and its relatively short hash length makes it easier to store and transmit.\n\nSHA-224 hashes are stored on-chain as 56 hexadecimal characters.\n\nSee [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.",
+            "type": "string",
+            "enum": [
+              "sha224"
+            ]
+          },
+          {
+            "title": "SHA256",
+            "description": "Represents the SHA-256 algorithm. SHA-256 is a member of the SHA-2 family of hash functions that produces a 256-bit hash value. It is widely used in cryptography and other security-related applications. The computational cost of SHA-256 is moderate, and its hash length strikes a good balance between security and convenience.\n\nSHA-256 hashes are stored on-chain as 64 hexadecimal characters.\n\nSee [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.",
+            "type": "string",
+            "enum": [
+              "sha256"
+            ]
+          },
+          {
+            "title": "SHA384",
+            "description": "Represents the SHA-384 algorithm. SHA-384 is a variant of the SHA-2 family of hash functions that produces a 384-bit hash value. It is similar to SHA-512, but with a shorter output size. The computational cost of SHA-384 is relatively high, but its longer hash length provides better security against hash collisions.\n\nSHA-384 hashes are stored on-chain as 96 hexadecimal characters.\n\nSee [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.",
+            "type": "string",
+            "enum": [
+              "sha384"
+            ]
+          },
+          {
+            "title": "SHA512",
+            "description": "Represents the SHA-512 algorithm. SHA-512 is a member of the SHA-2 family of hash functions that produces a 512-bit hash value. It is widely used in cryptography and other security-related applications. The computational cost of SHA-512 is relatively high, but its longer hash length provides better security against hash collisions.\n\nSHA-512 hashes are stored on-chain as 128 hexadecimal characters.\n\nSee [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.",
+            "type": "string",
+            "enum": [
+              "sha512"
+            ]
+          }
+        ]
+      },
+      "PaginationConfig": {
+        "description": "PaginationConfig is the type carrying configuration for paginated queries.\n\nThe fields are optional and if not set, there is a default configuration.",
+        "type": "object",
+        "properties": {
+          "default_page_size": {
+            "description": "The default number of elements in a page.\n\nShall be less or equal than `max_page_size`. Default to '10' if not set.",
+            "default": 10,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "max_page_size": {
+            "description": "The maximum elements a page can contain.\n\nShall be less than `u32::MAX - 1`. Default to '30' if not set.",
+            "default": 30,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      },
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      }
+    }
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "description": "Execute messages",
+    "oneOf": [
+      {
+        "title": "StoreObject",
+        "description": "StoreObject store an object to the bucket and make the sender the owner of the object. The object is referenced by the hash of its content and this value is returned. If the object is already stored, it is a no-op. It may be pinned though.\n\nThe \"pin\" parameter specifies if the object should be pinned for the sender. In such case, the object cannot be removed (forget) from the storage.\n\nThe \"compression_algorithm\" parameter specifies the algorithm for compressing the object before storing it in the storage, which is optional. If no algorithm is specified, the algorithm used is the first algorithm of the bucket configuration limits. Note that the chosen algorithm can save storage space, but it will increase CPU usage. Depending on the chosen compression algorithm and the achieved compression ratio, the gas cost of the operation will vary, either increasing or decreasing.",
+        "type": "object",
+        "required": [
+          "store_object"
+        ],
+        "properties": {
+          "store_object": {
+            "type": "object",
+            "required": [
+              "data",
+              "pin"
+            ],
+            "properties": {
+              "compression_algorithm": {
+                "description": "Specifies the compression algorithm to use when storing the object. If None, the first algorithm specified in the list of accepted compression algorithms of the bucket is used (see [BucketLimits::accepted_compression_algorithms]).",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/CompressionAlgorithm"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "data": {
+                "description": "The content of the object to store.",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Binary"
+                  }
+                ]
+              },
+              "pin": {
+                "description": "Specifies if the object should be pinned for the sender.",
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "ForgetObject",
+        "description": "ForgetObject first unpin the object from the bucket for the considered sender, then remove it from the storage if it is not pinned anymore. If the object is pinned for other senders, it is not removed from the storage and an error is returned. If the object is not pinned for the sender, this is a no-op.",
+        "type": "object",
+        "required": [
+          "forget_object"
+        ],
+        "properties": {
+          "forget_object": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "PinObject",
+        "description": "PinObject pins the object in the bucket for the considered sender. If the object is already pinned for the sender, this is a no-op. While an object is pinned, it cannot be removed from the storage.",
+        "type": "object",
+        "required": [
+          "pin_object"
+        ],
+        "properties": {
+          "pin_object": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "UnpinObject",
+        "description": "UnpinObject unpins the object in the bucket for the considered sender. If the object is not pinned for the sender, this is a no-op. The object can be removed from the storage if it is not pinned anymore.",
+        "type": "object",
+        "required": [
+          "unpin_object"
+        ],
+        "properties": {
+          "unpin_object": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "Binary": {
+        "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+        "type": "string"
+      },
+      "CompressionAlgorithm": {
+        "description": "CompressionAlgorithm is an enumeration that defines the different compression algorithms supported for compressing the content of objects. The compression algorithm specified here are relevant algorithms for compressing data on-chain, which means that they are fast to compress and decompress, and have a low computational cost.\n\nThe order of the compression algorithms is based on their estimated computational cost (quite opinionated) during both compression and decompression, ranging from the lowest to the highest. This particular order is utilized to establish the default compression algorithm for storing an object.",
+        "oneOf": [
+          {
+            "title": "Passthrough",
+            "description": "Represents no compression algorithm. The object is stored as is without any compression.",
+            "type": "string",
+            "enum": [
+              "passthrough"
+            ]
+          },
+          {
+            "title": "Snappy",
+            "description": "Represents the Snappy algorithm. Snappy is a compression/decompression algorithm that does not aim for maximum compression. Instead, it aims for very high speeds and reasonable compression.\n\nSee [the snappy web page](https://google.github.io/snappy/) for more information.",
+            "type": "string",
+            "enum": [
+              "snappy"
+            ]
+          },
+          {
+            "title": "Lzma",
+            "description": "Represents the LZMA algorithm. LZMA is a lossless data compression/decompression algorithm that features a high compression ratio and a variable compression-dictionary size up to 4 GB.\n\nSee [the LZMA wiki page](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm) for more information.",
+            "type": "string",
+            "enum": [
+              "lzma"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "description": "Query messages",
+    "oneOf": [
+      {
+        "title": "Bucket",
+        "description": "Bucket returns the bucket information.",
+        "type": "object",
+        "required": [
+          "bucket"
+        ],
+        "properties": {
+          "bucket": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "Object",
+        "description": "Object returns the object information with the given id.",
+        "type": "object",
+        "required": [
+          "object"
+        ],
+        "properties": {
+          "object": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "description": "The id of the object to get.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "Objects",
+        "description": "Objects returns the list of objects in the bucket with support for pagination.",
+        "type": "object",
+        "required": [
+          "objects"
+        ],
+        "properties": {
+          "objects": {
+            "type": "object",
+            "properties": {
+              "address": {
+                "description": "The owner of the objects to get.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "after": {
+                "description": "The point in the sequence to start returning objects.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "first": {
+                "description": "The number of objects to return.",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "ObjectData",
+        "description": "ObjectData returns the content of the object with the given id.",
+        "type": "object",
+        "required": [
+          "object_data"
+        ],
+        "properties": {
+          "object_data": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "description": "The id of the object to get.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "title": "ObjectPins",
+        "description": "ObjectPins returns the list of addresses that pinned the object with the given id with support for pagination.",
+        "type": "object",
+        "required": [
+          "object_pins"
+        ],
+        "properties": {
+          "object_pins": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "after": {
+                "description": "The point in the sequence to start returning pins.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "first": {
+                "description": "The number of pins to return.",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "id": {
+                "description": "The id of the object to get the pins for.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": null,
+  "responses": {
+    "bucket": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "BucketResponse",
+      "description": "BucketResponse is the response of the Bucket query.",
+      "type": "object",
+      "required": [
+        "config",
+        "limits",
+        "name",
+        "pagination",
+        "stat"
+      ],
+      "properties": {
+        "config": {
+          "description": "The configuration of the bucket.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BucketConfig"
+            }
+          ]
+        },
+        "limits": {
+          "description": "The limits of the bucket.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BucketLimits"
+            }
+          ]
+        },
+        "name": {
+          "description": "The name of the bucket.",
+          "type": "string"
+        },
+        "pagination": {
+          "description": "The configuration for paginated query.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PaginationConfig"
+            }
+          ]
+        },
+        "stat": {
+          "description": "The statistics of the bucket.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/BucketStat"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "BucketConfig": {
+          "description": "BucketConfig is the type of the configuration of a bucket.\n\nThe configuration is set at the instantiation of the bucket, and is immutable and cannot be changed. The configuration is optional and if not set, the default configuration is used.",
+          "type": "object",
+          "properties": {
+            "accepted_compression_algorithms": {
+              "description": "The acceptable compression algorithms for the objects in the bucket. If this parameter is not set, then all compression algorithms are accepted. If this parameter is set, then only the compression algorithms in the array are accepted.\n\nWhen an object is stored in the bucket without a specified compression algorithm, the first algorithm in the array is used. Therefore, the order of the algorithms in the array is significant. Typically, the most efficient compression algorithm, such as the NoCompression algorithm, should be placed first in the array.\n\nAny attempt to store an object using a different compression algorithm than the ones specified here will fail.",
+              "default": [
+                "passthrough",
+                "snappy",
+                "lzma"
+              ],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CompressionAlgorithm"
+              }
+            },
+            "hash_algorithm": {
+              "description": "The algorithm used to hash the content of the objects to generate the id of the objects. The algorithm is optional and if not set, the default algorithm is used.\n\nThe default algorithm is Sha256 if not set.",
+              "default": "sha256",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/HashAlgorithm"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "BucketLimits": {
+          "description": "BucketLimits is the type of the limits of a bucket.\n\nThe limits are optional and if not set, there is no limit.",
+          "type": "object",
+          "properties": {
+            "max_object_pins": {
+              "description": "The maximum number of pins in the bucket for an object.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "max_object_size": {
+              "description": "The maximum size of the objects in the bucket.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "max_objects": {
+              "description": "The maximum number of objects in the bucket.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "max_total_size": {
+              "description": "The maximum total size of the objects in the bucket.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "BucketStat": {
+          "title": "BucketStat",
+          "description": "BucketStat is the type of the statistics of a bucket.",
+          "type": "object",
+          "required": [
+            "compressed_size",
+            "object_count",
+            "size"
+          ],
+          "properties": {
+            "compressed_size": {
+              "description": "The total size of the objects contained in the bucket after compression.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "object_count": {
+              "description": "The number of objects in the bucket.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "size": {
+              "description": "The total size of the objects contained in the bucket.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "CompressionAlgorithm": {
+          "description": "CompressionAlgorithm is an enumeration that defines the different compression algorithms supported for compressing the content of objects. The compression algorithm specified here are relevant algorithms for compressing data on-chain, which means that they are fast to compress and decompress, and have a low computational cost.\n\nThe order of the compression algorithms is based on their estimated computational cost (quite opinionated) during both compression and decompression, ranging from the lowest to the highest. This particular order is utilized to establish the default compression algorithm for storing an object.",
+          "oneOf": [
+            {
+              "title": "Passthrough",
+              "description": "Represents no compression algorithm. The object is stored as is without any compression.",
+              "type": "string",
+              "enum": [
+                "passthrough"
+              ]
+            },
+            {
+              "title": "Snappy",
+              "description": "Represents the Snappy algorithm. Snappy is a compression/decompression algorithm that does not aim for maximum compression. Instead, it aims for very high speeds and reasonable compression.\n\nSee [the snappy web page](https://google.github.io/snappy/) for more information.",
+              "type": "string",
+              "enum": [
+                "snappy"
+              ]
+            },
+            {
+              "title": "Lzma",
+              "description": "Represents the LZMA algorithm. LZMA is a lossless data compression/decompression algorithm that features a high compression ratio and a variable compression-dictionary size up to 4 GB.\n\nSee [the LZMA wiki page](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm) for more information.",
+              "type": "string",
+              "enum": [
+                "lzma"
+              ]
+            }
+          ]
+        },
+        "HashAlgorithm": {
+          "description": "HashAlgorithm is an enumeration that defines the different hash algorithms supported for hashing the content of objects.",
+          "oneOf": [
+            {
+              "title": "MD5",
+              "description": "Represents the MD5 algorithm. MD5 is a widely used cryptographic hash function that produces a 128-bit hash value. The computational cost of MD5 is relatively low compared to other hash functions, but its short hash length makes it easier to find hash collisions. It is now considered insecure for cryptographic purposes, but can still used in non-security contexts.\n\nMD5 hashes are stored on-chain as 32 hexadecimal characters.\n\nSee [the MD5 Wikipedia page](https://en.wikipedia.org/wiki/MD5) for more information.",
+              "type": "string",
+              "enum": [
+                "m_d5"
+              ]
+            },
+            {
+              "title": "SHA1",
+              "description": "Represents the SHA-224 algorithm. SHA-224 is a variant of the SHA-2 family of hash functions that produces a 224-bit hash value. It is similar to SHA-256, but with a shorter output size. The computational cost of SHA-224 is moderate, and its relatively short hash length makes it easier to store and transmit.\n\nSHA-224 hashes are stored on-chain as 56 hexadecimal characters.\n\nSee [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.",
+              "type": "string",
+              "enum": [
+                "sha224"
+              ]
+            },
+            {
+              "title": "SHA256",
+              "description": "Represents the SHA-256 algorithm. SHA-256 is a member of the SHA-2 family of hash functions that produces a 256-bit hash value. It is widely used in cryptography and other security-related applications. The computational cost of SHA-256 is moderate, and its hash length strikes a good balance between security and convenience.\n\nSHA-256 hashes are stored on-chain as 64 hexadecimal characters.\n\nSee [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.",
+              "type": "string",
+              "enum": [
+                "sha256"
+              ]
+            },
+            {
+              "title": "SHA384",
+              "description": "Represents the SHA-384 algorithm. SHA-384 is a variant of the SHA-2 family of hash functions that produces a 384-bit hash value. It is similar to SHA-512, but with a shorter output size. The computational cost of SHA-384 is relatively high, but its longer hash length provides better security against hash collisions.\n\nSHA-384 hashes are stored on-chain as 96 hexadecimal characters.\n\nSee [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.",
+              "type": "string",
+              "enum": [
+                "sha384"
+              ]
+            },
+            {
+              "title": "SHA512",
+              "description": "Represents the SHA-512 algorithm. SHA-512 is a member of the SHA-2 family of hash functions that produces a 512-bit hash value. It is widely used in cryptography and other security-related applications. The computational cost of SHA-512 is relatively high, but its longer hash length provides better security against hash collisions.\n\nSHA-512 hashes are stored on-chain as 128 hexadecimal characters.\n\nSee [the SHA-2 Wikipedia page](https://en.wikipedia.org/wiki/SHA-2) for more information.",
+              "type": "string",
+              "enum": [
+                "sha512"
+              ]
+            }
+          ]
+        },
+        "PaginationConfig": {
+          "description": "PaginationConfig is the type carrying configuration for paginated queries.\n\nThe fields are optional and if not set, there is a default configuration.",
+          "type": "object",
+          "properties": {
+            "default_page_size": {
+              "description": "The default number of elements in a page.\n\nShall be less or equal than `max_page_size`. Default to '10' if not set.",
+              "default": 10,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "max_page_size": {
+              "description": "The maximum elements a page can contain.\n\nShall be less than `u32::MAX - 1`. Default to '30' if not set.",
+              "default": 30,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "object": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ObjectResponse",
+      "description": "ObjectResponse is the response of the Object query.",
+      "type": "object",
+      "required": [
+        "compressed_size",
+        "compression_algorithm",
+        "id",
+        "is_pinned",
+        "owner",
+        "size"
+      ],
+      "properties": {
+        "compressed_size": {
+          "description": "The size of the object when compressed. If the object is not compressed, the value is the same as `size`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
+        },
+        "compression_algorithm": {
+          "description": "The compression algorithm used to compress the content of the object.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CompressionAlgorithm"
+            }
+          ]
+        },
+        "id": {
+          "description": "The id of the object.",
+          "type": "string"
+        },
+        "is_pinned": {
+          "description": "Tells if the object is pinned by at least one address.",
+          "type": "boolean"
+        },
+        "owner": {
+          "description": "The owner of the object.",
+          "type": "string"
+        },
+        "size": {
+          "description": "The size of the object.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "CompressionAlgorithm": {
+          "description": "CompressionAlgorithm is an enumeration that defines the different compression algorithms supported for compressing the content of objects. The compression algorithm specified here are relevant algorithms for compressing data on-chain, which means that they are fast to compress and decompress, and have a low computational cost.\n\nThe order of the compression algorithms is based on their estimated computational cost (quite opinionated) during both compression and decompression, ranging from the lowest to the highest. This particular order is utilized to establish the default compression algorithm for storing an object.",
+          "oneOf": [
+            {
+              "title": "Passthrough",
+              "description": "Represents no compression algorithm. The object is stored as is without any compression.",
+              "type": "string",
+              "enum": [
+                "passthrough"
+              ]
+            },
+            {
+              "title": "Snappy",
+              "description": "Represents the Snappy algorithm. Snappy is a compression/decompression algorithm that does not aim for maximum compression. Instead, it aims for very high speeds and reasonable compression.\n\nSee [the snappy web page](https://google.github.io/snappy/) for more information.",
+              "type": "string",
+              "enum": [
+                "snappy"
+              ]
+            },
+            {
+              "title": "Lzma",
+              "description": "Represents the LZMA algorithm. LZMA is a lossless data compression/decompression algorithm that features a high compression ratio and a variable compression-dictionary size up to 4 GB.\n\nSee [the LZMA wiki page](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm) for more information.",
+              "type": "string",
+              "enum": [
+                "lzma"
+              ]
+            }
+          ]
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "object_data": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Binary",
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
+      "type": "string"
+    },
+    "object_pins": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ObjectPinsResponse",
+      "description": "ObjectPinsResponse is the response of the GetObjectPins query.",
+      "type": "object",
+      "required": [
+        "data",
+        "page_info"
+      ],
+      "properties": {
+        "data": {
+          "description": "The list of addresses that pinned the object.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "page_info": {
+          "description": "The page information.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PageInfo"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "PageInfo": {
+          "title": "PageInfo",
+          "description": "PageInfo is the page information returned for paginated queries.",
+          "type": "object",
+          "required": [
+            "cursor",
+            "has_next_page"
+          ],
+          "properties": {
+            "cursor": {
+              "description": "The cursor to the next page.",
+              "type": "string"
+            },
+            "has_next_page": {
+              "description": "Tells if there is a next page.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "objects": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ObjectsResponse",
+      "description": "ObjectsResponse is the response of the Objects query.",
+      "type": "object",
+      "required": [
+        "data",
+        "page_info"
+      ],
+      "properties": {
+        "data": {
+          "description": "The list of objects in the bucket.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ObjectResponse"
+          }
+        },
+        "page_info": {
+          "description": "The page information.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PageInfo"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "CompressionAlgorithm": {
+          "description": "CompressionAlgorithm is an enumeration that defines the different compression algorithms supported for compressing the content of objects. The compression algorithm specified here are relevant algorithms for compressing data on-chain, which means that they are fast to compress and decompress, and have a low computational cost.\n\nThe order of the compression algorithms is based on their estimated computational cost (quite opinionated) during both compression and decompression, ranging from the lowest to the highest. This particular order is utilized to establish the default compression algorithm for storing an object.",
+          "oneOf": [
+            {
+              "title": "Passthrough",
+              "description": "Represents no compression algorithm. The object is stored as is without any compression.",
+              "type": "string",
+              "enum": [
+                "passthrough"
+              ]
+            },
+            {
+              "title": "Snappy",
+              "description": "Represents the Snappy algorithm. Snappy is a compression/decompression algorithm that does not aim for maximum compression. Instead, it aims for very high speeds and reasonable compression.\n\nSee [the snappy web page](https://google.github.io/snappy/) for more information.",
+              "type": "string",
+              "enum": [
+                "snappy"
+              ]
+            },
+            {
+              "title": "Lzma",
+              "description": "Represents the LZMA algorithm. LZMA is a lossless data compression/decompression algorithm that features a high compression ratio and a variable compression-dictionary size up to 4 GB.\n\nSee [the LZMA wiki page](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Markov_chain_algorithm) for more information.",
+              "type": "string",
+              "enum": [
+                "lzma"
+              ]
+            }
+          ]
+        },
+        "ObjectResponse": {
+          "title": "ObjectResponse",
+          "description": "ObjectResponse is the response of the Object query.",
+          "type": "object",
+          "required": [
+            "compressed_size",
+            "compression_algorithm",
+            "id",
+            "is_pinned",
+            "owner",
+            "size"
+          ],
+          "properties": {
+            "compressed_size": {
+              "description": "The size of the object when compressed. If the object is not compressed, the value is the same as `size`.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "compression_algorithm": {
+              "description": "The compression algorithm used to compress the content of the object.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/CompressionAlgorithm"
+                }
+              ]
+            },
+            "id": {
+              "description": "The id of the object.",
+              "type": "string"
+            },
+            "is_pinned": {
+              "description": "Tells if the object is pinned by at least one address.",
+              "type": "boolean"
+            },
+            "owner": {
+              "description": "The owner of the object.",
+              "type": "string"
+            },
+            "size": {
+              "description": "The size of the object.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "PageInfo": {
+          "title": "PageInfo",
+          "description": "PageInfo is the page information returned for paginated queries.",
+          "type": "object",
+          "required": [
+            "cursor",
+            "has_next_page"
+          ],
+          "properties": {
+            "cursor": {
+              "description": "The cursor to the next page.",
+              "type": "string"
+            },
+            "has_next_page": {
+              "description": "Tells if there is a next page.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "description": "# Objectarium\n\nA  [CosmWasm](https://cosmwasm.com/) Smart Contract which enables the storage of arbitrary unstructured [Objects](https://en.wikipedia.org/wiki/Object_storage) in any [Cosmos](https://cosmos.network/) blockchains.\n\n## Purpose\n\nThe smart contract serves as a robust storage solution, allowing for the storage of arbitrary `objects` on any blockchain within the [Cosmos blockchains](https://cosmos.network/) network, utilizing the [CosmWasm](https://cosmwasm.com/) framework. The key features of the contract include:\n\n**Versatile Data Storage:**\nThe contract is designed to accommodate any type of data, be it text, images, or complex data structures. This flexibility makes it an ideal choice for a wide range of decentralized applications (dApps) that require diverse storage needs.\n\n**On-chain Data:**\nBy design, the contract stores data on the blockchain, ensuring that it is immutable and publicly accessible. This is particularly useful for applications that require a high level of transparency, and also for any other smart contract that needs to store data on the blockchain.\n\n**Pinning and Unpinning:**\nOne unique feature is the ability to 'pin' and 'unpin' objects associated with a specific sender address. Pinning ensures that the object remains stored and accessible, while unpinning releases it from being permanently stored, offering a level of control over data persistence.\n\n**Object Removal:**\nThe contract also includes a 'forget' function, allowing for the removal of objects that are no longer pinned. This is particularly useful for managing storage costs and ensuring that only relevant data remains on the blockchain.\n\n**Cost Management:**\nFeatures like pinning, unpinning, and discarding objects offer a strategic way to control storage costs. Additionally, setting limits on contract size — for instance in terms of object count and their individual sizes — serves as a practical tool to regulate storage costs.\n\n## Rationale\n\nIn a sense, we can consider blockchains built on the [Cosmos L0](https://docs.cosmos.network/main) layer as decentralized databases, and their nature can be shaped and modeled through the smart contracts or modules. Given this, it provides a great opportunity to address the wide range of data management needs. One such important area is the management of unstructured, immutable data, which is written once but accessed frequently — commonly known as object storage. This is the primary focus of `axone-objectarium`: a specialized smart contract designed to offer a versatile and efficient approach to handling *on-chain*, *unstructured*, *immutable* data in a *decentralized* manner.\n\n## Terminology\n\n### Object\n\nIn the context of the `axone-objectarium` smart contract, an `object` refers to a piece of data stored on the blockchain. It can represent various types of information, such as documents, binary files, or any other digital content. Objects are immutable once stored and are identified by their cryptographic hash, which can be generated using algorithms like MD5 or SHA256. This ensures the integrity and security of the stored data, as any modification to the object would result in a different hash value.\n\n### Bucket\n\nThe smart contract is organized around buckets. A bucket represents a logical container within the `axone-objectarium` smart contract instance that groups related Objects together. It acts as a storage unit for Objects and provides a context for managing and organizing them. Each bucket has a unique name and is associated with a set of configurations and limits that define its behaviour and characteristics.\n\n### Pin\n\nPin refers to a mechanism that allows users to mark or \"pin\" specific objects within a bucket. Pinning an object serves as a way to ensure that the object remains in storage and cannot be removed (this is called \"forgotten\"). It provides protection and guarantees that the pinned object will persist in the protocol. When an object is pinned, it is associated with the identity (or sender) that performed the pinning action.\n\n## Usage\n\nThe unstructured nature of the data stored in the chain opens up a plethora of possibilities for decentralized applications that require this type of versatile storage.\n\n### In the AXONE protocol\n\nThe primary function of this smart contract within the AXONE protocol is to enable the persistence of governance rules, which are encoded in Prolog. These programs are stored in an immutable format within the protocol and can be referenced by their unique identifiers in situations where there is a need to refer to these rules.\n\n### In the wild world\n\nA plethora of possibilities opens up for decentralized applications (dApps) that require this kind of versatile storage. However, it's important to consider the following constraints: the data is immutable, the cost of recording the data is proportional to its size, and the data is publicly accessible.\n\n## Play\n\n### Instantiation\n\nThe `axone-objectarium` can be instantiated as follows, refer to the schema for more information on configuration, limits and pagination configuration:\n\n```bash\naxoned tx wasm instantiate $CODE_ID \\\n    --label \"my-storage\" \\\n    --from $ADDR \\\n    --admin $ADMIN_ADDR \\\n    --gas 1000000 \\\n    '{\"bucket\":\"my-bucket\"}'\n```\n\n### Execution\n\nWe can store an object by providing its data in base64 encoded, we can pin the stored object to prevent it from being removed:\n\n```bash\naxoned tx wasm execute $CONTRACT_ADDR \\\n    --from $ADDR \\\n    --gas 1000000 \\\n    \"{\\\"store_object\\\":{\\\"data\\\": \\\"$(cat my-data | base64)\\\",\\\"pin\\\":true}}\"\n```\n\nThe object id is stable as it is a hash, we can't store an object twice.\n\nWith the following commands we can pin and unpin existing objects:\n\n```bash\naxoned tx wasm execute $CONTRACT_ADDR \\\n    --from $ADDR \\\n    --gas 1000000 \\\n    \"{\\\"pin_object\\\":{\\\"id\\\": \\\"$OBJECT_ID\\\"}}\"\n\naxoned tx wasm execute $CONTRACT_ADDR \\\n    --from $ADDR \\\n    --gas 1000000 \\\n    \"{\\\"unpin_object\\\":{\\\"id\\\": \\\"$OBJECT_ID\\\"}}\"\n```\n\nAnd if an object is not pinned, or pinned by the sender of transaction, we can remove it:\n\n```bash\naxoned tx wasm execute $CONTRACT_ADDR \\\n    --from $ADDR \\\n    --gas 1000000 \\\n    \"{\\\"forget_object\\\":{\\\"id\\\": \\\"$OBJECT_ID\\\"}}\"\n```\n\n### Querying\n\nQuery an object by its id:\n\n```bash\naxoned query wasm contract-state smart $CONTRACT_ADDR \\\n    \"{\\\"object\\\": {\\\"id\\\": \\\"$OBJECT_ID\\\"}}\"\n```\n\nOr its data:\n\n```bash\naxoned query wasm contract-state smart $CONTRACT_ADDR \\\n    \"{\\\"object_data\\\": {\\\"id\\\": \\\"$OBJECT_ID\\\"}}\"\n```\n\nWe can also list the objects, eventually filtering on the object owner:\n\n```bash\naxoned query wasm contract-state smart $CONTRACT_ADDR \\\n    \"{\\\"objects\\\": {\\\"address\\\": \\\"axone1p8u47en82gmzfm259y6z93r9qe63l25d858vqu\\\"}}\"\n```\n\nAnd navigate in a cursor based pagination:\n\n```bash\naxoned query wasm contract-state smart $CONTRACT_ADDR \\\n    \"{\\\"objects\\\": {\\\"first\\\": 5, \\\"after\\\": \\\"23Y5t5DBe7DkPwfJo3Sd26Y8Z9epmtpA1FTpdG7DiG6MD8vPRTzzbQ9TccmyoBcePkPK6atUiqcAzJVo3TfYNBGY\\\"}}\"\n```\n\nWe can also query object pins with the same cursor based pagination:\n\n```bash\naxoned query wasm contract-state smart $CONTRACT_ADDR \\\n    \"{\\\"object_pins\\\": {\\\"id\\\": \\\"$OBJECT_ID\\\", \\\"first\\\": 5, \\\"after\\\": \\\"23Y5t5DBe7DkPwfJo3Sd26Y8Z9epmtpA1FTpdG7DiG6MD8vPRTzzbQ9TccmyoBcePkPK6atUiqcAzJVo3TfYNBGY\\\"}}\"\n```",
+  "title": "axone-objectarium"
+}

--- a/ts/cognitarium-schema/package.json
+++ b/ts/cognitarium-schema/package.json
@@ -25,7 +25,7 @@
         "typescript": "^4.6.3"
     },
     "scripts": {
-        "clean": "rm -rf gen-ts && mkdir gen-ts",
+        "clean": "rm -rf gen-ts && rm -rf dist && mkdir gen-ts",
         "build": "tsc"
     },
     "exports": "./dist/schema.d.ts",

--- a/ts/dataverse-schema/package.json
+++ b/ts/dataverse-schema/package.json
@@ -25,7 +25,7 @@
         "typescript": "^4.6.3"
     },
     "scripts": {
-        "clean": "rm -rf gen-ts && mkdir gen-ts",
+        "clean": "rm -rf gen-ts && rm -rf dist && mkdir gen-ts",
         "build": "tsc"
     },
     "exports": "./dist/schema.d.ts",

--- a/ts/law-stone-schema/package.json
+++ b/ts/law-stone-schema/package.json
@@ -25,7 +25,7 @@
         "typescript": "^4.6.3"
     },
     "scripts": {
-        "clean": "rm -rf gen-ts && mkdir gen-ts",
+        "clean": "rm -rf gen-ts && rm -rf dist && mkdir gen-ts",
         "build": "tsc"
     },
     "exports": "./dist/schema.d.ts",

--- a/ts/objectarium-schema/package.json
+++ b/ts/objectarium-schema/package.json
@@ -25,7 +25,7 @@
         "typescript": "^4.6.3"
     },
     "scripts": {
-        "clean": "rm -rf gen-ts && mkdir gen-ts",
+        "clean": "rm -rf gen-ts && rm -rf dist && mkdir gen-ts",
         "build": "tsc"
     },
     "exports": "./dist/schema.d.ts",


### PR DESCRIPTION
Due to issues encountered with the [quicktype](https://quicktype.io/typescript) library, specifically in relation to the generated `cognitarium` schema type (refer to issue #9), we have decided to switch to the [ts-codegen](https://github.com/CosmWasm/ts-codegen) library. [ ts-codegen](https://github.com/CosmWasm/ts-codegen) has been specifically designed for smart-contract schemas, making it a more suitable choice for our project. 
This PR removes the usage of quicktype for TypeScript (the removal for Go will be addressed in the upcoming PR #38) and generates new schema types using ts-codegen.  

In addition to the switch in libraries, this PR also includes modifications to the package.json file and introduces a cleaning step to generated typescript files. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced JSON schema for `axone-law-stone` and `axone-dataverse` contracts.

- **Enhancements**
  - Updated TypeScript type generation to use `ts-codegen` for improved performance.
  - Clean scripts for various packages now also remove `dist` directories for more thorough cleaning.

- **Bug Fixes**
  - Excluded `.json` files from specific workflow processes to prevent unnecessary operations.

- **Chores**
  - Added exclusion for JSON files in the `schema` directory from the review process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->