### PR TITLE
Remove `v` prefix on typescript package version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         registry:
           - url: "https://npm.pkg.github.com"
-            auth-token-secret: NPM_REGISTRY_TOKEN
+            auth-token-secret: GITHUB_TOKEN
           - url: "https://registry.npmjs.org"
             auth-token-secret: NPM_PUBLIC_REGISTRY_TOKEN
         schema: ${{ fromJson(needs.schema-matrix.outputs.schema) }}

--- a/magefiles/utils.go
+++ b/magefiles/utils.go
@@ -81,7 +81,7 @@ func parseVersion(tag string) (*Version, error) {
 }
 
 func (v *Version) String() string {
-	return fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 }
 
 // EnsureGit ensures that git is installed, if not it panics.

--- a/ts/cognitarium-schema/package.json
+++ b/ts/cognitarium-schema/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@axone/cognitarium-schema",
-    "version": "v3.0.0",
+    "version": "3.0.0",
     "private": false,
     "repository": {
         "type": "git",

--- a/ts/dataverse-schema/package.json
+++ b/ts/dataverse-schema/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@axone/objectarium-dataverse",
-    "version": "v3.0.0",
+    "version": "3.0.0",
     "private": false,
     "repository": {
         "type": "git",

--- a/ts/law-stone-schema/package.json
+++ b/ts/law-stone-schema/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@axone/law-stone-schema",
-    "version": "v3.0.0",
+    "version": "3.0.0",
     "private": false,
     "repository": {
         "type": "git",

--- a/ts/objectarium-schema/package.json
+++ b/ts/objectarium-schema/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@axone/objectarium-schema",
-    "version": "v3.0.0",
+    "version": "3.0.0",
     "private": false,
     "repository": {
         "type": "git",


### PR DESCRIPTION
This PR addresses the suggestion proposed in issue #34 to remove the 'v' prefix from the version for TypeScript packages. This change aims to streamline our versioning system and align it with common practices.

In addition to this primary change, this PR also includes work to resolve issues encountered during the publication process on NPM. Both the NPM registry and GitHub registry failed to publish the package, as detailed in this [workflow run](https://github.com/axone-protocol/axone-contract-schema/actions/runs/9677290518/job/26698628138).

Based on the [GitHub documentation](https://docs.github.com/fr/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authentification-dans-un-workflow-github-actions), try to use the `GITHUB_TOKEN` for publishing the package on the GitHub npm registry. This change is being tested as the current method (using a Personal Access Token) is not allowing package creation, possibly due to this being the first publication attempt. More informations about this issue [See this discussion](https://github.com/orgs/community/discussions/36020#discussioncomment-3908733).

I have also investigating issues with the `NPM_PUBLIC_REGISTRY_TOKEN`. The publication process is failing due to a 'not found' error. It's unclear whether this is due to an incorrect scope setting or an issue with the token itself, as the @axone organization could not be found on npm. Further investigation and verification are required to resolve this issue.
