### PR TITLE
ci(workflow): fix missing repository checkout in publish-new-schema job

### DIFF
--- a/.github/workflows/update-schema.yml
+++ b/.github/workflows/update-schema.yml
@@ -48,8 +48,8 @@ jobs:
           go-version: "1.22"
           cache: true
           cache-dependency-path: |
-              **/go.sum
-              **/go.mod
+            **/go.sum
+            **/go.mod
 
       - name: Setup rust
         uses: actions-rs/toolchain@v1
@@ -138,6 +138,12 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build-target
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.OPS_TOKEN }}
+          fetch-depth: 2
+
       - name: Download artefact
         uses: actions/download-artifact@v4
         with:
@@ -185,4 +191,4 @@ jobs:
           commit_author: ${{ vars.BOT_GIT_AUTHOR_NAME }} <${{ vars.BOT_GIT_AUTHOR_EMAIL }}>
           commit_message: "${{ github.event.inputs.draft == 'true' && 'feat: update schema files' || 'chore(release): perform release' }} ${{ github.event.inputs.draft == 'false' && github.event.inputs.ref || '' }}"
           tagging_message: ${{ github.event.inputs.draft == 'false' && github.event.inputs.ref || '' }}
-          file_pattern: '*.json */README.md go/**/*.go'
+          file_pattern: "*.json */README.md go/**/*.go"


### PR DESCRIPTION
The `publish-new-schema` job was missing a repository checkout step, causing `git status` to fail with:

> publish-new-schema
git-status failed with:<fatal: not a git repository (or any of the parent directories): .git>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced the background update process by adding a secure step to ensure reliable access to repository content during updates.
- **Style**
	- Standardized formatting for dependency caching and commit pattern steps to improve consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->